### PR TITLE
Small rewrite for mech.py for speed-dependent load torque profiles.

### DIFF
--- a/examples/im/plot_obs_vhz_ctrl_im_2kw.py
+++ b/examples/im/plot_obs_vhz_ctrl_im_2kw.py
@@ -40,16 +40,24 @@ ctrl = mt.InductionMotorVHzObsCtrl(
     mt.InductionMotorObsVHzCtrlPars(slip_compensation=False))
 
 # %%
-# Set the speed reference and the external load torque.
+# Set the speed reference.
 
 # Speed reference
 times = np.array([0, .125, .25, .375, .5, .625, .75, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, -1, -1, 0, 0])*base.w
 ctrl.w_m_ref = mt.Sequence(times, values)
+
+# %%
+# Set the load torque reference
+
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, 0])*base.tau_nom
 mdl.mech.tau_L_ext = mt.Sequence(times, values)
+
+# Fan load profile (uncomment to enable)
+#k = base.tau_nom/(0.95*base.w/base.p)**2
+#mdl.mech.tau_L_w = lambda w_M: np.sign(w_M)*k*w_M**2
 
 # %%
 # Create the simulation object and simulate it. You can also enable the PWM

--- a/examples/sm_with_signal_inj/plot_signal_inj_pmsm_2kw.py
+++ b/examples/sm_with_signal_inj/plot_signal_inj_pmsm_2kw.py
@@ -24,7 +24,7 @@ base = mt.BaseValues(
 # Configure the system model.
 
 motor = mt.SynchronousMotor(p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
-mech = mt.Mechanics(J=.015, B=0)
+mech = mt.Mechanics(J=.015)
 conv = mt.Inverter()
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 

--- a/examples/sm_with_signal_inj/plot_signal_inj_syrm_7kw.py
+++ b/examples/sm_with_signal_inj/plot_signal_inj_syrm_7kw.py
@@ -27,7 +27,7 @@ base = mt.BaseValues(
 motor = mt.SynchronousMotor(p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
 # You may also try the model of a saturated SyRM below
 # motor = mt.SynchronousMotorSaturated()
-mech = mt.Mechanics(J=.015, B=0)
+mech = mt.Mechanics(J=.015)
 conv = mt.Inverter()
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 

--- a/motulator/model/im_drive.py
+++ b/motulator/model/im_drive.py
@@ -138,7 +138,7 @@ class InductionMotorDrive:
             self.motor.p*self.data.theta_M + np.pi, 2*np.pi) - np.pi
         self.data.w_m = self.motor.p*self.data.w_M
         self.data.tau_L = (
-            self.mech.tau_L_ext(self.data.t) + self.mech.B*self.data.w_M)
+            self.mech.tau_L_ext(self.data.t) + self.mech.tau_L_w(self.data.w_M))
         self.data.u_ss = self.conv.ac_voltage(self.data.q, self.conv.u_dc0)
 
         # Compute the inverse-Γ rotor flux

--- a/motulator/model/mech.py
+++ b/motulator/model/mech.py
@@ -17,12 +17,15 @@ class Mechanics:
         Viscous damping coefficient.
     tau_L_ext : function
         External load torque as a function of time, `tau_L_ext(t)`.
-
+    tau_L_ext : function
+        Load torque as function of speed, `tau_L_w(w_M)`.
+        For example, tau_L_w = B*w_M, where B is the viscous friction coefficient.
     """
 
-    def __init__(self, J=.015, B=0, tau_L_ext=lambda t: 0):
-        self.J, self.B = J, B
+    def __init__(self, J=.015, tau_L_w = lambda w_M: 0, tau_L_ext=lambda t: 0):
+        self.J = J
         self.tau_L_ext = tau_L_ext
+        self.tau_L_w = tau_L_w
         # Initial values
         self.w_M0, self.theta_M0 = 0, 0
 
@@ -45,7 +48,7 @@ class Mechanics:
             Time derivative of the state vector.
 
         """
-        dw_M = (tau_M - self.B*w_M - self.tau_L_ext(t))/self.J
+        dw_M = (tau_M - self.tau_L_w(w_M) - self.tau_L_ext(t))/self.J
         dtheta_M = w_M
         return [dw_M, dtheta_M]
 

--- a/motulator/model/sm_drive.py
+++ b/motulator/model/sm_drive.py
@@ -137,7 +137,7 @@ class SynchronousMotorDrive:
         self.data.i_s, self.data.tau_M = self.motor.magnetic(self.data.psi_s)
         self.data.w_m = self.motor.p*self.data.w_M
         self.data.tau_L = (
-            self.mech.tau_L_ext(self.data.t) + self.mech.B*self.data.w_M)
+            self.mech.tau_L_ext(self.data.t) + self.mech.tau_L_w(self.data.w_M))
         self.data.u_ss = self.conv.ac_voltage(self.data.q, self.conv.u_dc0)
         self.data.theta_M = np.mod(  # Limit into [-pi, pi)
             self.data.theta_M + np.pi, 2*np.pi) - np.pi


### PR DESCRIPTION
Load torque profile can be defined as function of the rotor speed. (see plot_obs_vhz_ctrl_im_2kw.py for an example)

Note that the wiki page might differ from this approach slightly:
https://aalto-electric-drives.github.io/motulator/mechanics.html