### PR TITLE
Replace LinearNDInterpolator with NearestNDInterpolator in LUT-based models

### DIFF
--- a/examples/sm_with_flux_maps/plot_obs_vhz_ctrl_pmsyrm_thor.py
+++ b/examples/sm_with_flux_maps/plot_obs_vhz_ctrl_pmsyrm_thor.py
@@ -1,8 +1,8 @@
 """
-Observer-based V/Hz control: 7.5-kW PM-SyRM
+Observer-based V/Hz control: 5-kW PM-SyRM
 ===========================================
 
-This example simulates observer-based V/Hz control of a saturated 7.5-kW
+This example simulates observer-based V/Hz control of a saturated 5-kW
 permanent-magnet synchronous reluctance motor. The flux maps of this example
 motor, known as THOR, are from the SyR-e project:
 
@@ -28,7 +28,7 @@ import motulator as mt
 # Compute base values based on the nominal values (just for figures).
 
 base = mt.BaseValues(
-    U_nom=284, I_nom=18, f_nom=100, tau_nom=23.8, P_nom=7.5e3, p=2)
+    U_nom=220, I_nom=15.6, f_nom=85, tau_nom=19, P_nom=5.07e3, p=2)
 
 # %%
 # Load and plot the flux maps.
@@ -42,11 +42,11 @@ mt.plot_flux_map(data)
 
 # Create the motor model
 motor = mt.SynchronousMotorSaturatedLUT(
-    p=2, R_s=.23, psi_s_data=data.psi_s.ravel(), i_s_data=data.i_s.ravel())
+    p=2, R_s=.2, psi_s_data=data.psi_s.ravel(), i_s_data=data.i_s.ravel())
 # Magnetically linear PM-SyRM model
-# motor = mt.SynchronousMotor(p=2, R_s=.23, L_d=4.2e-3, L_q=17.3e-3, psi_f=.17)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=400)
+# motor = mt.SynchronousMotor(p=2, R_s=.2, L_d=4e-3, L_q=17e-3, psi_f=.134)
+mech = mt.Mechanics(J=.0042)
+conv = mt.Inverter(u_dc=310)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%
@@ -54,16 +54,15 @@ mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 pars = mt.SynchronousMotorVHzObsCtrlPars(
     p=2,
-    R_s=.23,
-    L_d=4.2e-3,
-    L_q=17.3e-3,
-    psi_f=.17,
+    R_s=.2,
+    L_d=4e-3,
+    L_q=17e-3,
+    psi_f=.134,
     alpha_psi=2*np.pi*50,
     zeta_inf=.1,
     T_s=250e-6,
-    rate_limit=2*np.pi*120*10,
     i_s_max=2*base.i,
-    psi_s_min=.5*base.psi,
+    psi_s_min=.3*base.psi,
     psi_s_max=1.5*base.psi,
 )
 ctrl = mt.SynchronousMotorVHzObsCtrl(pars)
@@ -80,8 +79,11 @@ ctrl.w_m_ref = mt.Sequence(times, values)
 k = base.tau_nom/(base.w/base.p)**2
 mdl.mech.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
 
-# Rated load torque step at t = 2.5 s (set k = 0 above)
-# mdl.mech.tau_L_t = lambda t: (t > 2.5)*base.tau_nom
+# Uncomment to try the rated load torque step at t = 1 s (set k = 0 above)
+# times = np.array([0, .125, .125, .875, .875, 1])*8
+# values = np.array([0, 0, 1, 1, 0, 0])*base.tau_nom
+# mdl.mech.tau_L_t = mt.Sequence(times, values)
+
 
 # %%
 # Create the simulation object and simulate it. You can also enable the PWM

--- a/examples/two_mass_systems/plot_vector_ctrl_pmsm_2kw_two_mass.py
+++ b/examples/two_mass_systems/plot_vector_ctrl_pmsm_2kw_two_mass.py
@@ -3,16 +3,10 @@ Observer-based V/Hz control: 2.2-kW PMSM with two-mass mechanics
 ================================================================
 
 This example simulates observer-based V/Hz control of a 2.2-kW PMSM drive. The
-mechanical subsystem is modeled as a two-mass system. The mechanical parameters
-correspond approximately to [1]_, except that the torsional damping is set to
-a smaller value in this example. The resonance freuqency of the mechanics is
-around 85 Hz.
-
-References
-----------
-.. [1] Saarakkala, Hinkkanen, "Identification of two-mass mechanical
-   systems using torque excitation: Design and experimental evaluation,"
-   IEEE Trans. Ind. Appl., 2015, https://doi.org/10.1109/tia.2015.2416128.
+mechanical subsystem is modeled as a two-mass system. The resonance frequency
+of the mechanics is around 85 Hz. The mechanical parameters correspond
+approximately to https://doi.org/10.1109/tia.2015.2416128, except that the
+torsional damping is set to a smaller value in this example.
 
 """
 

--- a/motulator/__init__.py
+++ b/motulator/__init__.py
@@ -36,8 +36,6 @@ from motulator.model.sm_flux_maps import (
     import_syre_data,
     plot_flux_map,
     plot_flux_vs_current,
-    invert_flux_map,
-    downsample_flux_map,
 )
 
 # Import controllers


### PR DESCRIPTION
LinearNDInterpolator was used as a LUT-based saturation model for synchronous machines. However, for some unknown reason, LinearNDInterpolator shows surprisingly large interpolation errors, which may cause additional phenomena in the simulation (see also discussion here https://github.com/scipy/scipy/issues/17378). Therefore, LinearNDInterpolator is replaced with NearestNDInterpolator that has the same user interface. It is worth noticing that the nearest interpolation requires high-resolution saturation data. The nearest interpolation can be later replaced with a more suitable linear interpolation method (maybe RegularGridInterpolator).