### PR TITLE
Methods for downsampling and inverting flux maps

### DIFF
--- a/examples/sm_with_flux_maps/plot_obs_vhz_ctrl_pmsyrm_thor.py
+++ b/examples/sm_with_flux_maps/plot_obs_vhz_ctrl_pmsyrm_thor.py
@@ -33,7 +33,13 @@ base = mt.BaseValues(
 # %%
 # Load and plot the flux maps.
 
+# Load the data from the MATLAB file
 data = mt.import_syre_data(fname='THOR.mat')
+# You may also downsample or invert the flux map by uncommenting the following
+# lines. Not needed here, but these methods could be useful for other purposes.
+# from motulator.model.sm_flux_maps import downsample_flux_map, invert_flux_map
+# data = downsample_flux_map(data, N_d=32, N_q=32)
+# data = invert_flux_map(data, N_d=128, N_q=128)
 mt.plot_flux_vs_current(data)
 mt.plot_flux_map(data)
 


### PR DESCRIPTION
This pull request add simple methods for downsampling and inverting flux maps.

These methods (downsample_flux_map and invert_flux_map) are not currently necessary, since the scipy.interpolator.LinearNDInterpolator used in the LUT-based motor model (SynchronousMotorSaturatedLUT) can operated with scattered data. However, these downsampling and inversion methods might be beneficial for parametrising LUT-based saturation models used in control algorithms. 