### PR TITLE
Minor simplifications regarding implentation of some vector projections

### DIFF
--- a/motulator/control/im_obs_vhz.py
+++ b/motulator/control/im_obs_vhz.py
@@ -250,7 +250,7 @@ class SensorlessFluxObserver:
         lambd = self.zeta_inf*np.abs(w_s) + .5*self.alpha
         # Observer gain (without the orthogonal projection which is
         # embedded into the state update)
-        g_o = 2*lambd*(self.alpha + 1j*self.w_m)/(self.alpha**2 + self.w_m**2)
+        g_o = 2*lambd/(self.alpha - 1j*self.w_m)
 
         # Time derivative of the stator current
         di_s = (i_s - self.i_s_old)/self.T_s
@@ -261,8 +261,7 @@ class SensorlessFluxObserver:
             (self.alpha - 1j*self.w_m)*self.psi_R - u_s)
 
         # Error signal
-        psi_R_sqr = np.abs(self.psi_R)**2
-        err = e*np.conj(self.psi_R)/psi_R_sqr if psi_R_sqr > 0 else 0
+        err = e/self.psi_R if np.abs(self.psi_R) > 0 else 0
 
         # Update the states
         self.w_m -= self.T_s*self.alpha_o*err.imag

--- a/motulator/control/im_vector.py
+++ b/motulator/control/im_vector.py
@@ -405,7 +405,7 @@ class SensorlessObserver:
         # Observer gain (17) with c = w_s**2 (without the orthogonal projection
         # which is embedded into the state update)
         b = alpha + 2*self.zeta_inf*np.abs(self.w_m)
-        g = b*(alpha + 1j*self.w_m)/(alpha**2 + self.w_m**2)
+        g = b/(alpha - 1j*self.w_m)
 
         # Induced voltage from stator quantities, cf. (7)
         e_s = u_s - self.R_s*i_s - self.L_sgm*(i_s - self.i_s_old)/self.T_s

--- a/motulator/control/sm_obs_vhz.py
+++ b/motulator/control/sm_obs_vhz.py
@@ -128,14 +128,13 @@ class SynchronousMotorVHzObsCtrl(Ctrl):
         tau_M_ref = self.tau_M_ref
 
         # Limited flux and torque references
-        psi_s_ref, tau_M_ref_lim = self.flux_torque_ref(
-            tau_M_ref, w_m_ref, u_dc)
+        psi_s_ref, _ = self.flux_torque_ref(tau_M_ref, w_m_ref, u_dc)
 
         # Electromagnetic torque (7d)
         tau_M = 1.5*self.p*np.imag(i_s*np.conj(psi_s))
 
         # Dynamic frequency (5a)
-        w_s = w_m_ref - self.k_tau*(tau_M - tau_M_ref_lim)
+        w_s = w_m_ref - self.k_tau*(tau_M - tau_M_ref)
 
         # Voltage reference (4)
         err = psi_s_ref - psi_s


### PR DESCRIPTION
Some projections are implemented in a more compact (but mathematically equivalent) form, which is possible with complex space vectors. 

In observer-based V/Hz control for synchronous machines, the input signal to the high-pass filter is changed from the limited torque reference to the unlimited one, corresponding to the ECCE 2022 paper.