### PR TITLE
Fix the default load torque functions

### DIFF
--- a/motulator/model/mech.py
+++ b/motulator/model/mech.py
@@ -20,7 +20,8 @@ class Mechanics:
 
     """
 
-    def __init__(self, J=.015, tau_L_w=lambda w_M: 0, tau_L_t=lambda t: 0):
+    def __init__(
+            self, J=.015, tau_L_w=lambda w_M: 0*w_M, tau_L_t=lambda t: 0*t):
         self.J = J
         self.tau_L_t = tau_L_t
         self.tau_L_w = tau_L_w
@@ -116,8 +117,8 @@ class MechanicsTwoMass(Mechanics):
             J_L=.005,
             K_S=700.,
             C_S=.13,
-            tau_L_w=lambda w_M: 0,
-            tau_L_t=lambda t: 0):
+            tau_L_w=lambda w_M: 0*w_M,
+            tau_L_t=lambda t: 0*t):
         # pylint: disable=too-many-arguments
         # pylint: disable=super-init-not-called
         self.J_M = J_M


### PR DESCRIPTION
The default load torque functions tau_L_t and tau_L_w were changed to output a zero array if the input is a zero array. Therefore, they can be used in the post-processing stage.