### PR TITLE
Remove default parameters from system models, improve docstrings, simplify saturation models

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,7 @@ https://aalto-electric-drives.github.io/motulator/installation.html
 
 Usage
 -----
-The following example shows how to create a continuous-time system model, a discrete-time controller, and a simulation object:
-```python3
-import motulator as mt
-
-# Continuous-time model for the drive system
-motor = mt.InductionMotor()     # Motor model
-mech = mt.Mechanics()           # Mechanics model
-conv = mt.Inverter() 	        # Converter model
-mdl = mt.InductionMotorDrive(motor, mech, conv)
-
-# Discrete-time controller 
-pars = mt.InductionMotorVectorCtrlPars() 	# Dataclass of control parameters
-ctrl = mt.InductionMotorVectorCtrl(pars) 	# Sensorless controller
-
-# Create a simulation object, simulate, and plot example figures
-sim = mt.Simulation(mdl, ctrl)
-sim.simulate()
-mt.plot(sim)
-```
-This example applies the default settings. The drive system, controller, reference sequences etc. are easy to configure. The example scripts and Jupyter notebooks can be downloaded here:
+The drive system, controller, reference sequences etc. are easy to configure. As a starting point, example scripts and Jupyter notebooks can be downloaded here:
 
 https://aalto-electric-drives.github.io/motulator/auto_examples/index.html
 

--- a/docs/source/induction_motor.rst
+++ b/docs/source/induction_motor.rst
@@ -36,7 +36,7 @@ where :math:`L_\mathrm{s}` is the stator inductance and :math:`L_\ell` is the le
 .. math::
     \tau_\mathrm{M} = \frac{3 n_\mathrm{p}}{2}\mathrm{Im} \left\{\boldsymbol{i}_\mathrm{s}^\mathrm{s} (\boldsymbol{\psi}_\mathrm{s}^\mathrm{s})^* \right\}
 
-The class :class:`motulator.model.im.InductionMotorSaturated` extends the model with the main flux saturation, :math:`L_\mathrm{s} = L_\mathrm{s}(\psi_\mathrm{s})` [2]_.
+The class :class:`motulator.model.im.InductionMotorSaturated` extends the model with the main flux saturation, :math:`L_\mathrm{s} = L_\mathrm{s}(\psi_\mathrm{s})` [2]_. See also the example :doc:`/auto_examples/vhz/plot_vhz_ctrl_im_2kw`.
 
 .. note::
    If the magnetic saturation is omitted, the Γ model is mathematically identical to the inverse-Γ and T models. For example, the parameters of the Γ model can be transformed to those of the inverse-Γ model parameters as follows:

--- a/docs/source/synchronous_motor.rst
+++ b/docs/source/synchronous_motor.rst
@@ -24,7 +24,7 @@ where :math:`\boldsymbol{u}_\mathrm{s}` is the stator voltage, :math:`\boldsymbo
 where :math:`L_\mathrm{d}` is the d-axis inductance, :math:`L_\mathrm{q}` is the q-axis inductance, :math:`\psi_\mathrm{f}` is the permanent-magnet (PM) flux linkage. As special cases, this model represents a surface-PMSM with :math:`L_\mathrm{d} = L_\mathrm{q}` and SyRM with :math:`\psi_\mathrm{f}=0`.
 
 .. note::
-    The linear magnetic model can be replaced with nonlinear saturation characteristics  :math:`\boldsymbol{\psi}_\mathrm{s} = \boldsymbol{\psi}_\mathrm{s}(\boldsymbol{i}_\mathrm{s})`, either in a form of flux maps (see :class:`motulator.model.sm.SynchronousMotorSaturatedLUT`) or explicit functions (see :class:`motulator.model.sm.SynchronousMotorSaturated` corresponding to  [2]_). The module :mod:`motulator.model.sm_flux_maps` contains methods for importing and plotting the flux map data.
+    The linear magnetic model can be replaced with nonlinear saturation characteristics :math:`\boldsymbol{\psi}_\mathrm{s} = \boldsymbol{\psi}_\mathrm{s}(\boldsymbol{i}_\mathrm{s})`, either in a form of flux maps or explicit functions [2]_, see :class:`motulator.model.sm.SynchronousMotorSaturated`. The module :mod:`motulator.model.sm_flux_maps` contains methods for importing and plotting the flux map data. See also the examples :doc:`/auto_examples/flux_maps/plot_obs_vhz_ctrl_pmsyrm_thor` and :doc:`/auto_examples/vhz/plot_obs_vhz_ctrl_syrm_7kw`.
 
 The electromagnetic torque is
 

--- a/examples/flux_vector/README.txt
+++ b/examples/flux_vector/README.txt
@@ -1,2 +1,2 @@
-Flux Vector Control
+Flux-Vector Control
 -------------------

--- a/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
+++ b/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
@@ -23,7 +23,7 @@ base = mt.BaseValues(
 
 motor = mt.SynchronousMotor()
 mech = mt.Mechanics()
-conv = mt.Inverter()
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%

--- a/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
+++ b/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
@@ -21,8 +21,8 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor()
-mech = mt.Mechanics()
+motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mech = mt.Mechanics(J=.015)
 conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 

--- a/examples/flux_vector/plot_flux_vector_syrm_7kw.py
+++ b/examples/flux_vector/plot_flux_vector_syrm_7kw.py
@@ -21,13 +21,33 @@ base = mt.BaseValues(
     U_nom=370, I_nom=15.5, f_nom=105.8, tau_nom=20.1, P_nom=6.7e3, n_p=2)
 
 # %%
+# Create a saturation model, see the example
+# :doc:`/auto_examples/vhz/plot_obs_vhz_ctrl_syrm_7kw` for further details.
+
+
+def i_s(psi_s):
+    """Magnetic model for a 6.7-kW synchronous reluctance motor."""
+    # Parameters
+    a_d0, a_dd, S = 17.4, 373., 5  # d-axis self-saturation
+    a_q0, a_qq, T = 52.1, 658., 1  # q-axis self-saturation
+    a_dq, U, V = 1120., 1, 0  # Cross-saturation
+    # Inverse inductance functions
+    G_d = a_d0 + a_dd*np.abs(psi_s.real)**S + (
+        a_dq/(V + 2)*np.abs(psi_s.real)**U*np.abs(psi_s.imag)**(V + 2))
+    G_q = a_q0 + a_qq*np.abs(psi_s.imag)**T + (
+        a_dq/(U + 2)*np.abs(psi_s.real)**(U + 2)*np.abs(psi_s.imag)**V)
+    # Stator current
+    return G_d*psi_s.real + 1j*G_q*psi_s.imag
+
+
+# %%
 # Configure the system model.
 
-# Saturated SyRM model
-motor = mt.SynchronousMotorSaturated()
-# Magnetically linear SyRM model below (uncomment to try)
-# motor = mt.SynchronousMotor(n_p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
-mech = mt.Mechanics()
+motor = mt.SynchronousMotorSaturated(n_p=2, R_s=.54, current=i_s)
+
+# Magnetically linear SyRM model
+# motor = mt.SynchronousMotor(p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
+mech = mt.Mechanics(J=.015)
 conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 

--- a/examples/flux_vector/plot_flux_vector_syrm_7kw.py
+++ b/examples/flux_vector/plot_flux_vector_syrm_7kw.py
@@ -28,7 +28,7 @@ motor = mt.SynchronousMotorSaturated()
 # Magnetically linear SyRM model below (uncomment to try)
 # motor = mt.SynchronousMotor(n_p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
 mech = mt.Mechanics()
-conv = mt.Inverter()
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%

--- a/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
+++ b/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
@@ -25,7 +25,7 @@ base = mt.BaseValues(
 
 motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 mech = mt.Mechanics(J=.015)
-conv = mt.Inverter()
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%

--- a/examples/signal_inj/plot_signal_inj_syrm_7kw.py
+++ b/examples/signal_inj/plot_signal_inj_syrm_7kw.py
@@ -28,7 +28,7 @@ motor = mt.SynchronousMotor(n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
 # You may also try the model of a saturated SyRM below
 # motor = mt.SynchronousMotorSaturated()
 mech = mt.Mechanics(J=.015)
-conv = mt.Inverter()
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%

--- a/examples/two_mass_systems/plot_vector_ctrl_pmsm_2kw_two_mass.py
+++ b/examples/two_mass_systems/plot_vector_ctrl_pmsm_2kw_two_mass.py
@@ -26,9 +26,9 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-mech = mt.MechanicsTwoMass(J_M=.005, J_L=.005, K_S=700, C_S=.01)
-motor = mt.SynchronousMotor()
-conv = mt.Inverter()
+mech = mt.MechanicsTwoMass(J_M=.005, J_L=.005, K_S=700, C_S=.01)  # C_S=.13
+motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDriveTwoMass(motor, mech, conv)
 
 # %%

--- a/examples/vector/plot_vector_ctrl_pmsm_2kw.py
+++ b/examples/vector/plot_vector_ctrl_pmsm_2kw.py
@@ -21,9 +21,9 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor()
-mech = mt.Mechanics()
-conv = mt.Inverter()
+motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mech = mt.Mechanics(J=.015)
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%

--- a/examples/vector/plot_vector_ctrl_syrm_7kw.py
+++ b/examples/vector/plot_vector_ctrl_syrm_7kw.py
@@ -23,7 +23,7 @@ base = mt.BaseValues(
 
 motor = mt.SynchronousMotor(n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
 mech = mt.Mechanics(J=.015)
-conv = mt.Inverter()
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%

--- a/examples/vhz/plot_obs_vhz_ctrl_im_2kw.py
+++ b/examples/vhz/plot_obs_vhz_ctrl_im_2kw.py
@@ -30,10 +30,9 @@ base = mt.BaseValues(
 # Configure the induction motor using its inverse-Γ parameters
 motor = mt.InductionMotorInvGamma(
     R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224, n_p=2)
-
-mech = mt.Mechanics(J=.015)  # Mechanics model
-conv = mt.Inverter(u_dc=540)  # Inverter model
-mdl = mt.InductionMotorDrive(motor, mech, conv)  # System model
+mech = mt.Mechanics(J=.015)
+conv = mt.Inverter(u_dc=540)
+mdl = mt.InductionMotorDrive(motor, mech, conv)
 
 # %%
 # Configure the control system.

--- a/examples/vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
+++ b/examples/vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
@@ -23,7 +23,7 @@ base = mt.BaseValues(
 
 motor = mt.SynchronousMotor()
 mech = mt.Mechanics()
-conv = mt.Inverter()
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%

--- a/examples/vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
+++ b/examples/vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
@@ -21,8 +21,8 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor()
-mech = mt.Mechanics()
+motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mech = mt.Mechanics(J=.015)
 conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 

--- a/examples/vhz/plot_obs_vhz_ctrl_syrm_7kw.py
+++ b/examples/vhz/plot_obs_vhz_ctrl_syrm_7kw.py
@@ -21,14 +21,65 @@ base = mt.BaseValues(
     U_nom=370, I_nom=15.5, f_nom=105.8, tau_nom=20.1, P_nom=6.7e3, n_p=2)
 
 # %%
+# A saturation model is created based on [1]_, [2]_. For simplicity, the
+# saturation model parameters are hard-coded in function below, but the same
+# model structure can also be used for other synchronous motors. For PM motors,
+# the magnetomotive force (MMF) of the PMs can be modeled using constant current
+# source `i_f` on the d-axis [2], [3]_. Correspondingly, this approach assumes
+# that the MMFs of the d-axis current and of the PMs are in series. This model
+# cannot capture the desaturation phenomenon of thin iron ribs, see [4]_ for
+# details. For such motors, look-up tables can be used.
+
+
+def i_s(psi_s):
+    """
+    Magnetic model for a 6.7-kW synchronous reluctance motor.
+
+    Parameters
+    ----------
+    psi_s : complex
+        Stator flux linkage (Vs).
+
+    Returns
+    -------
+    complex
+        Stator current (A).
+
+    Notes
+    -----
+    For nonzero `i_f`, the initial value of the stator flux linkage `psi_s0` 
+    needs to be solved, e.g., as follows::
+
+    from scipy.optimize import minimize_scalar
+    res = minimize_scalar(
+        lambda psi_d: np.abs(
+                    (a_d0 + a_dd*np.abs(psi_d)**S)*psi_d - i_f))
+    psi_s0 = complex(res.x)
+
+    """
+    # Parameters
+    a_d0, a_dd, S = 17.4, 373., 5  # d-axis self-saturation
+    a_q0, a_qq, T = 52.1, 658., 1  # q-axis self-saturation
+    a_dq, U, V = 1120., 1, 0  # Cross-saturation
+    i_f = 0  # MMF of PMs
+    # Inverse inductance functions
+    G_d = a_d0 + a_dd*np.abs(psi_s.real)**S + (
+        a_dq/(V + 2)*np.abs(psi_s.real)**U*np.abs(psi_s.imag)**(V + 2))
+    G_q = a_q0 + a_qq*np.abs(psi_s.imag)**T + (
+        a_dq/(U + 2)*np.abs(psi_s.real)**(U + 2)*np.abs(psi_s.imag)**V)
+    # Stator current
+    return G_d*psi_s.real - i_f + 1j*G_q*psi_s.imag
+
+
+# %%
 # Configure the system model.
 
-# Saturated SyRM model
-motor = mt.SynchronousMotorSaturated()
+motor = mt.SynchronousMotorSaturated(n_p=2, R_s=.54, current=i_s)
+
 # Magnetically linear SyRM model
 # motor = mt.SynchronousMotor(p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
 mech = mt.Mechanics(J=.015)
-conv = mt.Inverter()
+conv = mt.Inverter(u_dc=540)
 mdl = mt.SynchronousMotorDrive(motor, mech, conv)
 
 # %%
@@ -71,3 +122,23 @@ sim.simulate(t_stop=8)
 # the results in SI units.
 
 mt.plot(sim, base=base)
+
+# %%
+# References
+# ----------
+# .. [1] Hinkkanen, Pescetto, Mölsä, Saarakkala, Pellegrino, Bojoi,
+#    “Sensorless self-commissioning of synchronous reluctance motors at
+#    standstill without rotor locking, ”IEEE Trans. Ind. Appl., 2017,
+#    https://doi.org/10.1109/TIA.2016.2644624
+#
+# .. [2] Awan, Song, Saarakkala, Hinkkanen, "Optimal torque control of
+#    saturated synchronous motors: plug-and-play method," IEEE Trans. Ind.
+#    Appl., 2018, https://doi.org/10.1109/TIA.2018.2862410
+#
+# .. [3] Jahns, Kliman, Neumann, “Interior permanent-magnet synchronous
+#    motors for adjustable-speed drives,” IEEE Trans. Ind. Appl., 1986,
+#    https://doi.org/10.1109/TIA.1986.4504786
+#
+# .. [4] Armando, Guglielmi, Pellegrino, Pastorelli, Vagati, "Accurate
+#    modeling and performance analysis of IPM-PMASR motors," IEEE Trans. Ind.
+#    Appl., 2009, https://doi.org/10.1109/TIA.2008.2009493

--- a/examples/vhz/plot_vhz_ctrl_6step_im_2kw.py
+++ b/examples/vhz/plot_vhz_ctrl_6step_im_2kw.py
@@ -29,9 +29,9 @@ base = mt.BaseValues(
 motor = mt.InductionMotorInvGamma(
     R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224, n_p=2)
 
-mech = mt.Mechanics(J=.016)  # Mechanics model
-conv = mt.Inverter(u_dc=540)  # Inverter model
-mdl = mt.InductionMotorDrive(motor, mech, conv)  # System model
+mech = mt.Mechanics(J=.016)
+conv = mt.Inverter(u_dc=540)
+mdl = mt.InductionMotorDrive(motor, mech, conv)
 
 # %%
 # Control system (parametrized as open-loop V/Hz control).
@@ -56,7 +56,7 @@ mdl.mech.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
 mdl.mech.tau_L_t = lambda t: (t > 1.)*base.tau_nom*0
 
 # %%
-# Create the simulation object and simulate it. The option `pwm=True` enables
+# Create the simulation object and simulate it. The option ``pwm=True`` enables
 # the model for the carrier comparison.
 
 sim = mt.Simulation(mdl, ctrl, pwm=True)

--- a/examples/vhz/plot_vhz_ctrl_im_2kw.py
+++ b/examples/vhz/plot_vhz_ctrl_im_2kw.py
@@ -3,7 +3,8 @@ V/Hz control: 2.2-kW induction motor
 ====================================
 
 A diode bridge, stiff three-phase grid, and a DC link is modeled. The default
-parameters correspond to open-loop V/Hz control.
+parameters correspond to open-loop V/Hz control. Magnetic saturation of the 
+motor is also modeled.
 
 """
 # %%
@@ -20,11 +21,38 @@ base = mt.BaseValues(
     U_nom=400, I_nom=5, f_nom=50, tau_nom=14.6, P_nom=2.2e3, n_p=2)
 
 # %%
+# The main-flux saturation model is created based on [1]_. For simplicity, the
+# parameters are hard-coded in the function below, but this model structure can
+# be used also for other induction motors.
+
+
+def L_s(psi):
+    """
+    Stator inductance saturation model for a 2.2-kW motor.
+
+    Parameters
+    ----------
+    psi : float
+        Magnitude of the stator flux linkage (Vs).
+    
+    Returns
+    -------
+    float
+        Stator inductance (H).
+
+    """
+    # Saturation model parameters for a 2.2-kW induction motor
+    L_su, beta, S = .34, .84, 7
+    # Stator inductance
+    return L_su/(1 + (beta*psi)**S)
+
+
+# %%
 # Create the system model.
 
 # Γ-equivalent motor model with main-flux saturation included
 motor = mt.InductionMotorSaturated(
-    R_s=3.7, R_r=2.5, L_ell=.023, L_su=.34, beta=.84, S=7, n_p=2)
+    n_p=2, R_s=3.7, R_r=2.5, L_ell=.023, L_s=L_s)
 # Mechanics model
 mech = mt.Mechanics(J=.015)
 # Frequency converter with a diode bridge
@@ -67,9 +95,18 @@ print(f'\nExecution time: {(time() - t_start):.2f} s')
 #    The DC link of this particular example is actually unstable at 1-p.u.
 #    speed at the rated load torque, since the inverter looks like a negative
 #    resistance to the DC link. You could notice this instability if simulating
-#    a longer period (e.g. set `t_stop=2`). For more information, see e.g.
-#    https://doi.org/10.1109/EPE.2007.4417763
+#    a longer period (e.g. set `t_stop=2`). For more information, see e.g. [2]_.
 
 # sphinx_gallery_thumbnail_number = 2
 mt.plot(sim, base=base)
 mt.plot_extra(sim, t_span=(1.1, 1.125), base=base)
+
+# %%
+# References
+# ----------
+# .. [1] Qu, Ranta, Hinkkanen, Luomi, "Loss-minimizing flux level control of
+#    induction motor drives," IEEE Trans. Ind. Appl., 2012,
+#    https://doi.org/10.1109/TIA.2012.2190818
+# .. [2] Hinkkanen, Harnefors, Luomi, "Control of induction motor drives
+#    equipped with small DC-Link capacitance," Proc. EPE, 2007,
+#    https://doi.org/10.1109/EPE.2007.4417763

--- a/motulator/__init__.py
+++ b/motulator/__init__.py
@@ -21,7 +21,6 @@ from motulator.model.im import (
 from motulator.model.sm import (
     SynchronousMotor,
     SynchronousMotorSaturated,
-    SynchronousMotorSaturatedLUT,
 )
 from motulator.model.im_drive import (
     InductionMotorDrive,

--- a/motulator/model/converter.py
+++ b/motulator/model/converter.py
@@ -4,8 +4,7 @@ Power converter models.
 An inverter with constant DC-bus voltage and a frequency converter with a diode
 front-end rectifier are modeled. Complex space vectors are used also for duty
 ratios and switching states, wherever applicable. In this module, all space
-vectors are in stationary coordinates. The default values correspond to a
-2.2-kW 400-V motor drive.
+vectors are in stationary coordinates. 
 
 """
 import numpy as np
@@ -19,11 +18,11 @@ class Inverter:
     Parameters
     ----------
     u_dc : float
-        DC-bus voltage.
+        DC-bus voltage (V).
 
     """
 
-    def __init__(self, u_dc=540):
+    def __init__(self, u_dc):
         self.u_dc0 = u_dc
         self.q = 0j  # Switching state vector
 
@@ -37,12 +36,12 @@ class Inverter:
         q : complex
             Switching state vector.
         u_dc : float
-            DC-bus voltage.
+            DC-bus voltage (V).
 
         Returns
         -------
         u_ac : complex
-            AC-side voltage.
+            AC-side voltage (V).
 
         """
         u_ac = q*u_dc
@@ -58,12 +57,12 @@ class Inverter:
         q : complex
             Switching state vector.
         i_ac : complex
-            AC-side current.
+            AC-side current (A).
 
         Returns
         -------
         i_dc : float
-            DC-side current.
+            DC-side current (A).
 
         """
         i_dc = 1.5*np.real(q*np.conj(i_ac))
@@ -76,7 +75,7 @@ class Inverter:
         Returns
         -------
         float
-            DC-bus voltage.
+            DC-bus voltage (V).
 
         """
         return self.u_dc0
@@ -94,17 +93,17 @@ class FrequencyConverter(Inverter):
     Parameters
     ----------
     L : float
-        DC-bus inductance.
+        DC-bus inductance (H).
     C : float
-        DC-bus capacitance.
+        DC-bus capacitance (F).
     U_g : float
-        Grid voltage (line-line, rms).
+        Grid voltage (V, line-line, rms).
     f_g : float
-        Grid frequency.
+        Grid frequency (Hz).
 
     """
 
-    def __init__(self, L=2e-3, C=235e-6, U_g=400, f_g=50):
+    def __init__(self, L, C, U_g, f_g):
         # pylint: disable=super-init-not-called
         self.L, self.C = L, C
         # Initial value of the DC-bus inductor current
@@ -125,12 +124,12 @@ class FrequencyConverter(Inverter):
         Parameters
         ----------
         t : float
-            Time.
+            Time (s).
 
         Returns
         -------
         u_g_abc : ndarray of floats, shape (3,)
-            The phase voltages.
+            Phase voltages (V).
 
         """
         theta_g = self.w_g*t
@@ -148,18 +147,18 @@ class FrequencyConverter(Inverter):
         Parameters
         ----------
         t : float
-            Time.
+            Time (s).
         u_dc : float
-            DC-bus voltage over the capacitor.
+            DC-bus voltage (V) over the capacitor.
         i_L : float
-            DC-bus inductor current.
+            DC-bus inductor current (A).
         i_dc : float
-            Current to the inverter.
+            Current to the inverter (A).
 
         Returns
         -------
         list, length 2
-            Time derivative of the state vector, [du_dc, d_iL]
+            Time derivative of the state vector, [du_dc, di_L]
 
         """
         # Grid phase voltages

--- a/motulator/model/im.py
+++ b/motulator/model/im.py
@@ -178,7 +178,7 @@ class InductionMotorSaturated(InductionMotor):
         Rotor resistance (Ohm).
     L_ell : float
         Leakage inductance (H).
-    L_s : Callable[[float], float]
+    L_s : callable
         Stator inductance (H) as a function of the stator-flux magnitude.
 
     """

--- a/motulator/model/im_drive.py
+++ b/motulator/model/im_drive.py
@@ -29,7 +29,7 @@ class InductionMotorDrive:
 
     """
 
-    def __init__(self, motor, mech, conv):
+    def __init__(self, motor=None, mech=None, conv=None):
         self.motor = motor
         self.mech = mech
         self.conv = conv
@@ -171,7 +171,7 @@ class InductionMotorDriveDiode(InductionMotorDrive):
 
     """
 
-    def __init__(self, motor, mech, conv):
+    def __init__(self, motor=None, mech=None, conv=None):
         super().__init__(motor, mech, conv)
         self.conv = conv
         self.data.u_dc, self.data.i_L = [], []
@@ -247,8 +247,8 @@ class InductionMotorDriveTwoMass(InductionMotorDrive):
 
     """
 
-    def __init__(self, motor, mech, conv):
-        super().__init__(motor=motor, mech=mech, conv=conv)
+    def __init__(self, motor=None, mech=None, conv=None):
+        super().__init__(motor, mech, conv)
         self.data.w_L, self.data.theta_ML = [], []
 
     def get_initial_values(self):

--- a/motulator/model/im_drive.py
+++ b/motulator/model/im_drive.py
@@ -2,12 +2,10 @@
 Continuous-time models for induction motor drives.
 
 Peak-valued complex space vectors are used. The space vector models are
-implemented in stator coordinates. The default values correspond to a 2.2-kW
-induction motor.
+implemented in stator coordinates. 
 
 """
 import numpy as np
-
 from motulator.helpers import abc2complex, Bunch
 
 
@@ -31,7 +29,7 @@ class InductionMotorDrive:
 
     """
 
-    def __init__(self, motor=None, mech=None, conv=None):
+    def __init__(self, motor, mech, conv):
         self.motor = motor
         self.mech = mech
         self.conv = conv
@@ -66,6 +64,8 @@ class InductionMotorDrive:
 
         Parameters
         ----------
+        t0 : float
+            Initial time (s).
         x0 : complex ndarray
             Initial values of the state variables.
 
@@ -85,7 +85,7 @@ class InductionMotorDrive:
         Parameters
         ----------
         t : float
-            Time.
+            Time (s).
         x : complex ndarray
             State vector.
 
@@ -171,8 +171,8 @@ class InductionMotorDriveDiode(InductionMotorDrive):
 
     """
 
-    def __init__(self, motor=None, mech=None, conv=None):
-        super().__init__(motor=motor, mech=mech)
+    def __init__(self, motor, mech, conv):
+        super().__init__(motor, mech, conv)
         self.conv = conv
         self.data.u_dc, self.data.i_L = [], []
 
@@ -247,7 +247,7 @@ class InductionMotorDriveTwoMass(InductionMotorDrive):
 
     """
 
-    def __init__(self, motor=None, mech=None, conv=None):
+    def __init__(self, motor, mech, conv):
         super().__init__(motor=motor, mech=mech, conv=conv)
         self.data.w_L, self.data.theta_ML = [], []
 

--- a/motulator/model/mech.py
+++ b/motulator/model/mech.py
@@ -24,8 +24,7 @@ class Mechanics:
 
     def __init__(self, J, tau_L_w=lambda w_M: 0*w_M, tau_L_t=lambda t: 0*t):
         self.J = J
-        self.tau_L_t = tau_L_t
-        self.tau_L_w = tau_L_w
+        self.tau_L_t, self.tau_L_w = tau_L_t, tau_L_w
         # Initial values
         self.w_M0, self.theta_M0 = 0, 0
 
@@ -117,10 +116,7 @@ class MechanicsTwoMass(Mechanics):
     def __init__(self, J_M, J_L, K_S, C_S, tau_L_w=None, tau_L_t=None):
         # pylint: disable=too-many-arguments
         # pylint: disable=super-init-not-called
-        self.J_M = J_M
-        self.J_L = J_L
-        self.K_S = K_S
-        self.C_S = C_S
+        self.J_M, self.J_L, self.K_S, self.C_S = J_M, J_L, K_S, C_S
         self.tau_L_w = tau_L_w if tau_L_w is not None else lambda w_L: 0*w_L
         self.tau_L_t = tau_L_t if tau_L_t is not None else lambda t: 0*t
         # Initial values

--- a/motulator/model/mech.py
+++ b/motulator/model/mech.py
@@ -11,17 +11,18 @@ class Mechanics:
     Parameters
     ----------
     J : float
-        Total moment of inertia.
-    tau_L_w : function
-        Load torque as function of speed, `tau_L_w(w_M)`. For example,
-        tau_L_w = b*w_M, where b is the viscous friction coefficient.
-    tau_L_t : function
-        Load torque as a function of time, `tau_L_t(t)`.
+        Total moment of inertia (kgm**2).
+    tau_L_w : callable
+        Load torque (Nm) as a function of speed, `tau_L_w(w_M)`. For example,
+        ``tau_L_w = b*w_M``, where `b` is the viscous friction coefficient. The
+        default is zero, ``lambda w_M: 0*w_M``.
+    tau_L_t : callable
+        Load torque (Nm) as a function of time, `tau_L_t(t)`. The default is 
+        zero, ``lambda t: 0*t``.
 
     """
 
-    def __init__(
-            self, J=.015, tau_L_w=lambda w_M: 0*w_M, tau_L_t=lambda t: 0*t):
+    def __init__(self, J, tau_L_w=lambda w_M: 0*w_M, tau_L_t=lambda t: 0*t):
         self.J = J
         self.tau_L_t = tau_L_t
         self.tau_L_w = tau_L_w
@@ -35,11 +36,11 @@ class Mechanics:
         Parameters
         ----------
         t : float
-            Time.
+            Time (s).
         w_M : float
-            Rotor angular speed (in mechanical rad/s).
+            Rotor angular speed (mechanical rad/s).
         tau_M : float
-            Electromagnetic torque.
+            Electromagnetic torque (Nm).
 
         Returns
         -------
@@ -63,7 +64,7 @@ class Mechanics:
         Returns
         -------
         w_M0 : float
-            Rotor angular speed (in mechanical rad/s).
+            Rotor angular speed (mechanical rad/s).
 
         """
         # The quantization noise of an incremental encoder could be modeled
@@ -79,7 +80,7 @@ class Mechanics:
         Returns
         -------
         theta_M0 : float
-            Rotor angle (in mechanical rad).
+            Rotor angle (mechanical rad).
 
         """
         return self.theta_M0
@@ -95,38 +96,33 @@ class MechanicsTwoMass(Mechanics):
     Parameters
     ----------
     J_M : float
-        Moment of inertia of the motor.
+        Motor moment of inertia (kgm**2).
     J_L : float
-        Moment of inertia of the load.
+        Load moment of inertia (kgm**2).
     K_S : float
-        Torsional stiffness of the shaft.
+        Shaft torsional stiffness (Nm).
     C_S : float
-        Torsional damping of the shaft.
-    tau_L_w : function
-        Load torque as function of the load speed, `tau_L_w(w_L)`. For example,
-        tau_L_w = b*w_L, where b is the viscous friction coefficient.
-    tau_L_t : function
-        Load torque as a function of time, `tau_L_t(t)`.
+        Shaft torsional damping (Nms).
+    tau_L_w : callable
+        Load torque (Nm) as a function of the load speed, `tau_L_w(w_L)`, e.g., 
+        ``tau_L_w = B*w_L``, where `B`is the viscous friction coefficient. The
+        default is zero, ``lambda w_L: 0*w_L``.
+    tau_L_t : callable
+        Load torque (Nm) as a function of time, `tau_L_t(t)`. The default is
+        zero, ``lambda t: 0*t``.
 
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(
-            self,
-            J_M=.005,
-            J_L=.005,
-            K_S=700.,
-            C_S=.13,
-            tau_L_w=lambda w_M: 0*w_M,
-            tau_L_t=lambda t: 0*t):
+    def __init__(self, J_M, J_L, K_S, C_S, tau_L_w=None, tau_L_t=None):
         # pylint: disable=too-many-arguments
         # pylint: disable=super-init-not-called
         self.J_M = J_M
         self.J_L = J_L
         self.K_S = K_S
         self.C_S = C_S
-        self.tau_L_t = tau_L_t
-        self.tau_L_w = tau_L_w
+        self.tau_L_w = tau_L_w if tau_L_w is not None else lambda w_L: 0*w_L
+        self.tau_L_t = tau_L_t if tau_L_t is not None else lambda t: 0*t
         # Initial values
         self.w_M0, self.theta_M0, self.w_L0, self.theta_ML0 = 0, 0, 0, 0
 
@@ -139,15 +135,15 @@ class MechanicsTwoMass(Mechanics):
         Parameters
         ----------
         t : float
-            Time.
+            Time (s).
         w_M : float
-            Rotor angular speed (in mechanical rad/s).
+            Rotor angular speed (mechanical rad/s).
         w_L : float
-            Load angular speed (in mechanical rad/s).
+            Load angular speed (mechanical rad/s).
         theta_ML : float
-            Twist angle, theta_M - theta_L (in mechanical rad).
+            Twist angle, theta_M - theta_L (mechanical rad).
         tau_M : float
-            Electromagnetic torque.
+            Electromagnetic torque (Nm).
 
         Returns
         -------
@@ -176,7 +172,7 @@ class MechanicsTwoMass(Mechanics):
         Returns
         -------
         w_L0 : float
-            Load angular speed (in mechanical rad/s).
+            Load angular speed (mechanical rad/s).
 
         """
         return self.w_L0
@@ -190,7 +186,7 @@ class MechanicsTwoMass(Mechanics):
         Returns
         -------
         theta_L0 : float
-            Rotor angle (in mechanical rad).
+            Rotor angle (mechanical rad).
 
         """
         theta_L0 = self.theta_M0 - self.theta_ML0

--- a/motulator/model/sm.py
+++ b/motulator/model/sm.py
@@ -30,20 +30,17 @@ class SynchronousMotor:
         q-axis inductance (H).
     psi_f : float
         PM-flux linkage (Vs).
-    mech : Mechanics
-        Model of the mechanical subsystem, needed only for the coordinate
-        transformation in the measure_currents method.
 
     """
 
-    def __init__(self, n_p, R_s, L_d, L_q, psi_f, mech=None):
+    def __init__(self, n_p, R_s, L_d, L_q, psi_f):
         # pylint: disable=too-many-arguments
         self.n_p, self.R_s = n_p, R_s
         self.L_d, self.L_q, self.psi_f = L_d, L_q, psi_f
         # Initial value
-        self.psi_s0 = self.psi_f + 0j
+        self.psi_s0 = complex(psi_f)
         # For the coordinate transformation
-        self._mech = mech
+        self._mech = None
 
     def current(self, psi_s):
         """
@@ -152,24 +149,21 @@ class SynchronousMotorSaturated(SynchronousMotor):
         Number of pole pairs.
     R_s : float
         Stator resistance (Ohm).
-    current : Callable[[complex], complex]
+    current : callable
         Function that computes the stator current `i_s` as a function of the 
         stator flux linkage `psi_s`. 
     psi_s0 : complex, optional
         Initial value of the stator flux linkage (Vs). The default is 0j. For
         PM motors, this should be solved from the the saturation model.
-    mech : Mechanics
-        Model of the mechanical subsystem, needed only for the coordinate
-        transformation in the measure_currents method.
 
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, n_p, R_s, current, psi_s0=0j, mech=None):
+    def __init__(self, n_p, R_s, current, psi_s0=0j):
         # pylint: disable=too-many-arguments, disable=super-init-not-called
         self.n_p, self.R_s = n_p, R_s
         self.current = current
         # For the coordinate transformation
-        self._mech = mech
+        self._mech = None
         # Initial value of the stator flux linkage
-        self.psi_s0 = psi_s0
+        self.psi_s0 = complex(psi_s0)

--- a/motulator/model/sm.py
+++ b/motulator/model/sm.py
@@ -7,8 +7,6 @@ used.
 
 """
 import numpy as np
-from scipy.optimize import minimize_scalar
-from scipy.interpolate import LinearNDInterpolator
 from motulator.helpers import complex2abc
 
 
@@ -18,29 +16,27 @@ class SynchronousMotor:
     Synchronous motor model.
 
     This models a synchronous motor in rotor coordinates. The stator flux
-    linkage is the state variable. The default values correspond to a 2.2-kW
-    permanent-magnet synchronous motor.
+    linkage is the state variable. 
 
     Parameters
     ----------
     n_p : int
         Number of pole pairs.
     R_s : float
-        Stator resistance.
+        Stator resistance (Ohm).
     L_d : float
-        d-axis inductance.
+        d-axis inductance (H).
     L_q : float
-        q-axis inductance.
+        q-axis inductance (H).
     psi_f : float
-        PM-flux linkage.
+        PM-flux linkage (Vs).
     mech : Mechanics
         Model of the mechanical subsystem, needed only for the coordinate
         transformation in the measure_currents method.
 
     """
 
-    def __init__(
-            self, n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545, mech=None):
+    def __init__(self, n_p, R_s, L_d, L_q, psi_f, mech=None):
         # pylint: disable=too-many-arguments
         self.n_p, self.R_s = n_p, R_s
         self.L_d, self.L_q, self.psi_f = L_d, L_q, psi_f
@@ -56,12 +52,12 @@ class SynchronousMotor:
         Parameters
         ----------
         psi_s : complex
-            Stator flux linkage.
+            Stator flux linkage (Vs).
 
         Returns
         -------
         i_s : complex
-            Stator current.
+            Stator current (A).
 
         """
         i_s = (psi_s.real - self.psi_f)/self.L_d + 1j*psi_s.imag/self.L_q
@@ -74,14 +70,14 @@ class SynchronousMotor:
         Parameters
         ----------
         psi_s : complex
-            Stator flux linkage.
+            Stator flux linkage (Vs).
 
         Returns
         -------
         i_s : complex
-            Stator current.
+            Stator current (A).
         tau_M : float
-            Electromagnetic torque.
+            Electromagnetic torque (Nm).
 
         """
         i_s = self.current(psi_s)
@@ -95,20 +91,20 @@ class SynchronousMotor:
         Parameters
         ----------
         psi_s : complex
-            Stator flux linkage.
+            Stator flux linkage (Vs).
         u_s : complex
-            Stator voltage.
+            Stator voltage (V).
         w_M : float
-            Rotor angular speed (in mechanical rad/s).
+            Rotor angular speed (mechanical rad/s).
 
         Returns
         -------
         dpsi_s : complex list
-            Time derivative of the stator flux linkage.
+            Time derivative of the stator flux linkage (V).
         i_s : complex
-            Stator current.
+            Stator current (A).
         tau_M : float
-            Electromagnetic torque.
+            Electromagnetic torque (Nm).
 
         Notes
         -----
@@ -129,7 +125,7 @@ class SynchronousMotor:
         Returns
         -------
         i_s_abc : 3-tuple of floats
-            Phase currents.
+            Phase currents (A).
 
         """
         i_s0 = self.current(self.psi_s0)
@@ -143,178 +139,37 @@ class SynchronousMotorSaturated(SynchronousMotor):
     """
     Model of a saturated synchronous motor.
 
-    This extends the SynchronousMotor class with an analytical saturation
-    model [1]_, [2]_. The permanent magnets (PMs) are assumed to be along the
-    d-axis. The default values correspond to a 6.7-kW synchronous reluctance
-    motor.
+    This overrides the linear magnetics model of the SynchronousMotor class
+    with a generic saturation model::
+
+        i_s = i_s(psi_s)
+        
+    The saturation model could be an analytical function or a look-up table. 
 
     Parameters
     ----------
     n_p : int
         Number of pole pairs.
     R_s : float
-        Stator resistance.
-    i_f : float
-        Constant current corresponding to the magnetomotive force (MMF) of PMs.
-        In the magnetically linear case, `i_f = psi_f/L_d`.
-    a_d0 : float
-        Nonnegative parameter of the saturation model. In the magnetically
-        linear case, `a_d0 = 1/L_d`.
-    a_q0 : float
-        Nonnegative parameter of the saturation model. In the magnetically
-        linear case, `a_q0 = 1/L_q`.
-    a_dd : float
-        Nonnegative constant defining the d-axis self-saturation together with
-        `S`. In the magnetically linear case, `a_dd = 0`.
-    a_qq : float
-        Nonnegative constant defining the q-axis self-saturation together with
-        `T`. In the magnetically linear case, `a_qq = 0`.
-    a_dq : float
-        Nonnegative constant defining the cross-saturation together with `U`
-        and `V`. In the magnetically linear case, `a_dq = 0`.
-    S : float
-        Nonnegative constant defining the d-axis self-saturation.
-    T : float
-        Nonnegative constant defining the q-axis self-saturation.
-    U : float
-        Nonnegative constant defining the cross-saturation.
-    V : float
-        Nonnegative constant defining the cross-saturation.
+        Stator resistance (Ohm).
+    current : Callable[[complex], complex]
+        Function that computes the stator current `i_s` as a function of the 
+        stator flux linkage `psi_s`. 
+    psi_s0 : complex, optional
+        Initial value of the stator flux linkage (Vs). The default is 0j. For
+        PM motors, this should be solved from the the saturation model.
     mech : Mechanics
         Model of the mechanical subsystem, needed only for the coordinate
         transformation in the measure_currents method.
-
-    Notes
-    -----
-    The magnetomotive force (MMF) of the PMs is modeled using constant current
-    source `i_f` on the d-axis [3]_. Correspondingly, this approach assumes
-    that the MMFs of the d-axis current and of the PMs are in series. This
-    model cannot capture the desaturation phenomenon of thin iron ribs [4]_.
-    For such motors, look-up tables can be used.
-
-    References
-    ----------
-    .. [1] Hinkkanen, Pescetto, Mölsä, Saarakkala, Pellegrino, Bojoi,
-       “Sensorless self-commissioning of synchronous reluctance motors at
-       standstill without rotor locking, ”IEEE Trans. Ind. Appl., 2017,
-       https://doi.org/10.1109/TIA.2016.2644624
-
-    .. [2] Awan, Song, Saarakkala, Hinkkanen, "Optimal torque control of
-       saturated synchronous motors: plug-and-play method," IEEE Trans. Ind.
-       Appl., 2018, https://doi.org/10.1109/TIA.2018.2862410
-
-    .. [3] Jahns, Kliman, Neumann, “Interior permanent-magnet synchronous
-       motors for adjustable-speed drives,” IEEE Trans. Ind. Appl., 1986,
-       https://doi.org/10.1109/TIA.1986.4504786
-
-    .. [4] Armando, Guglielmi, Pellegrino, Pastorelli, Vagati, "Accurate
-       modeling and performance analysis of IPM-PMASR motors," IEEE Trans. Ind.
-       Appl., 2009, https://doi.org/10.1109/TIA.2008.2009493
 
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(
-        self,
-        n_p=2,
-        R_s=.54,
-        i_f=0,
-        a_d0=17.4,
-        a_q0=52.1,
-        a_dd=373.,
-        a_qq=658.,
-        a_dq=1120.,
-        S=5,
-        T=1,
-        U=1,
-        V=0,
-        mech=None,
-    ):
+    def __init__(self, n_p, R_s, current, psi_s0=0j, mech=None):
         # pylint: disable=too-many-arguments, disable=super-init-not-called
         self.n_p, self.R_s = n_p, R_s
-        self.i_f, self.a_d0, self.a_q0 = i_f, a_d0, a_q0
-        self.a_dd, self.a_qq, self.a_dq = a_dd, a_qq, a_dq
-        self.S, self.T, self.U, self.V = S, T, U, V
-
-        # Initial value of the stator flux
-        if i_f == 0:
-            # No magnets
-            self.psi_s0 = 0j
-        else:
-            # Solve the stator flux caused by the magnets @ i_s = 0
-            res = minimize_scalar(
-                lambda psi_d: np.abs(
-                    (a_d0 + a_dd*np.abs(psi_d)**S)*psi_d - i_f))
-            self.psi_s0 = complex(res.x)
-            print(self.psi_s0)
-
+        self.current = current
         # For the coordinate transformation
         self._mech = mech
-
-    def current(self, psi_s):
-        """Override the base class method."""
-        abs_psi_d = np.abs(psi_s.real)
-        abs_psi_q = np.abs(psi_s.imag)
-
-        G_dd = self.a_d0 + self.a_dd*abs_psi_d**self.S
-        G_dq = self.a_dq/(self.V + 2)*abs_psi_d**self.U*abs_psi_q**(self.V + 2)
-        G_qq = self.a_q0 + self.a_qq*abs_psi_q**self.T
-        G_qd = self.a_dq/(self.U + 2)*abs_psi_d**(self.U + 2)*abs_psi_q**self.V
-
-        i_d = (G_dd + G_dq)*psi_s.real - self.i_f
-        i_q = (G_qq + G_qd)*psi_s.imag
-        i_s = i_d + 1j*i_q
-
-        return i_s
-
-
-# %%
-class SynchronousMotorSaturatedLUT(SynchronousMotor):
-    """
-    Look-up-table-based model of a saturated synchronous motor.
-
-    This extends the SynchronousMotor class with a saturation model, where the
-    stator current depends on the stator flux linkage. The coordinates assume
-    the PMSM convention, i.e., that the PM flux is along the d-axis.
-    Unstructured flux map data can be used.
-
-    Parameters
-    ----------
-    n_p : int
-        Number of pole pairs.
-    R_s : float
-        Stator resistance.
-    psi_s_data : ndarray of complex
-        Stator flux data points for creating the interpolant.
-    i_s_data : ndarray of complex
-        Stator current data values for creating the interpolant.
-    mech : Mechanics
-        Model of the mechanical subsystem, needed only for the coordinate
-        transformation in the measure_currents method.
-
-    """
-
-    # pylint: disable=too-many-arguments, disable=super-init-not-called
-    def __init__(
-            self, n_p=2, R_s=.20, psi_s_data=None, i_s_data=None, mech=None):
-
-        self.n_p, self.R_s = n_p, R_s
-
-        # Create the interpolant
-        self.i_s = LinearNDInterpolator(
-            list(zip(psi_s_data.real, psi_s_data.imag)), i_s_data)
-
-        # Solve the PM flux for the initial value of the stator flux
-        res = minimize_scalar(
-            lambda psi_d: np.abs(self.i_s(psi_d, 0)),
-            bounds=(0, np.max(psi_s_data.real)),
-            method='bounded')
-        self.psi_s0 = complex(res.x)
-
-        # For the coordinate transformation
-        self._mech = mech
-
-    def current(self, psi_s):
-        """Override the base class method."""
-        # Return the current as function of the flux linkage
-        return self.i_s(psi_s.real, psi_s.imag)
+        # Initial value of the stator flux linkage
+        self.psi_s0 = psi_s0

--- a/motulator/model/sm_drive.py
+++ b/motulator/model/sm_drive.py
@@ -28,7 +28,7 @@ class SynchronousMotorDrive:
 
     """
 
-    def __init__(self, motor, mech, conv):
+    def __init__(self, motor=None, mech=None, conv=None):
         self.motor = motor
         self.motor._mech = mech
         self.mech = mech
@@ -164,7 +164,7 @@ class SynchronousMotorDriveTwoMass(SynchronousMotorDrive):
 
     """
 
-    def __init__(self, motor, mech, conv):
+    def __init__(self, motor=None, mech=None, conv=None):
         super().__init__(motor, mech, conv)
         self.data.w_L, self.data.theta_ML = [], []
 

--- a/motulator/model/sm_drive.py
+++ b/motulator/model/sm_drive.py
@@ -1,8 +1,7 @@
 """
 Continuous-time models for synchronous motor drives.
 
-Peak-valued complex space vectors are used. The default values correspond to a
-2.2-kW permanent-magnet synchronous motor.
+Peak-valued complex space vectors are used.
 
 """
 import numpy as np
@@ -29,7 +28,7 @@ class SynchronousMotorDrive:
 
     """
 
-    def __init__(self, motor=None, mech=None, conv=None):
+    def __init__(self, motor, mech, conv):
         self.motor = motor
         self.motor._mech = mech
         self.mech = mech
@@ -66,6 +65,8 @@ class SynchronousMotorDrive:
 
         Parameters
         ----------
+        t0 : float
+            Initial time (s).
         x0 : complex ndarray
             Initial values of the state variables.
 
@@ -84,7 +85,7 @@ class SynchronousMotorDrive:
         Parameters
         ----------
         t : float
-            Time.
+            Time (s).
         x : complex ndarray
             State vector.
 
@@ -163,8 +164,8 @@ class SynchronousMotorDriveTwoMass(SynchronousMotorDrive):
 
     """
 
-    def __init__(self, motor=None, mech=None, conv=None):
-        super().__init__(motor=motor, mech=mech, conv=conv)
+    def __init__(self, motor, mech, conv):
+        super().__init__(motor, mech, conv)
         self.data.w_L, self.data.theta_ML = [], []
 
     def get_initial_values(self):

--- a/motulator/model/sm_flux_maps.py
+++ b/motulator/model/sm_flux_maps.py
@@ -39,10 +39,11 @@ def import_syre_data(fname='THOR.mat', add_negative_q_axis=True):
     -------
     Bunch object with the following fields defined:
     i_s : complex ndarray
-        Stator current data.
+        Stator current data (A).
     psi_s : complex ndarray
-        Stator flux linkage data.
+        Stator flux linkage data (Vs).
     tau_M : ndarray
+        Torque data (Nm).
 
     Notes
     -----
@@ -197,10 +198,11 @@ def downsample_flux_map(data, N_d=32, N_q=32):
     -------
     Bunch object with the following fields defined:
     i_s : complex ndarray, shape (N_d, N_q)
-        Stator current data.
+        Stator current data (A).
     psi_s : complex ndarray, shape (N_d, N_q)
-        Stator flux linkage data.
+        Stator flux linkage data (Vs).
     tau_M : ndarray, shape (N_d, N_q)
+        Torque data (Nm).
 
     """
     # Points at which to interpolate data
@@ -235,10 +237,11 @@ def invert_flux_map(data, N_d=32, N_q=32):
     -------
     Bunch object with the following fields defined:
     psi_s : complex ndarray, shape (N_d, N_q)
-        Stator flux linkage data.
+        Stator flux linkage data (Vs).
     i_s : complex ndarray, shape (N_d, N_q)
-        Stator current data.
+        Stator current data (A).
     tau_M : ndarray, shape (N_d, N_q)
+        Torque data (Nm).
 
     """
     # Get the range


### PR DESCRIPTION
- The default values were removed from system models. This change is expected to remove risk of user errors.
- Units of the parameters were added to the docstrings.
- Saturation models were simplified and generalized. The SynchronousMotorSaturated class can be now used with both analytical saturation models and look-up tables. The detailed examples of how to parametrize saturated motor models were moved to the example scripts.
- The usage example was removed from README.md.