### PR TITLE
Use theta_m as a state in SynchronousMachine, refactor examples to avoid creating unnecessary instances

### DIFF
--- a/examples/flux_maps/plot_obs_vhz_ctrl_pmsyrm_thor.py
+++ b/examples/flux_maps/plot_obs_vhz_ctrl_pmsyrm_thor.py
@@ -79,12 +79,13 @@ def i_s(psi_s):
 # Configure the system model.
 
 # Create the motor model
-motor = mt.SynchronousMotorSaturated(n_p=2, R_s=.2, current=i_s, psi_s0=psi_s0)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotorSaturated(
+    n_p=2, R_s=.2, current=i_s, psi_s0=psi_s0)
+mdl.mech = mt.Mechanics(J=.0042)
+mdl.conv = mt.Inverter(u_dc=310)
 # Magnetically linear PM-SyRM model
-# motor = mt.SynchronousMotor(n_p=2, R_s=.2, L_d=4e-3, L_q=17e-3, psi_f=.134)
-mech = mt.Mechanics(J=.0042)
-conv = mt.Inverter(u_dc=310)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+# mdl.motor = mt.SynchronousMotor(n_p=2, R_s=.2, L_d=4e-3, L_q=17e-3, psi_f=.134)
 
 # %%
 # Configure the control system.

--- a/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
+++ b/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
@@ -21,10 +21,10 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Configure the control system.

--- a/examples/flux_vector/plot_flux_vector_syrm_7kw.py
+++ b/examples/flux_vector/plot_flux_vector_syrm_7kw.py
@@ -43,13 +43,12 @@ def i_s(psi_s):
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotorSaturated(n_p=2, R_s=.54, current=i_s)
-
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotorSaturated(n_p=2, R_s=.54, current=i_s)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 # Magnetically linear SyRM model
-# motor = mt.SynchronousMotor(p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+# mdl.motor = mt.SynchronousMotor(p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
 
 # %%
 # Configure the control system.

--- a/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
+++ b/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
@@ -23,10 +23,10 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Configure the control system.

--- a/examples/signal_inj/plot_signal_inj_syrm_7kw.py
+++ b/examples/signal_inj/plot_signal_inj_syrm_7kw.py
@@ -24,16 +24,14 @@ base = mt.BaseValues(
 # Configure the system model.
 
 # Magnetically linear SyRM model
-motor = mt.SynchronousMotor(n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
-# You may also try the model of a saturated SyRM below
-# motor = mt.SynchronousMotorSaturated()
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotor(
+    n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
-# Configure the control system. (Note that the control system does not take
-# the magnetic saturation into account, if you try the saturated model.)
+# Configure the control system.
 
 pars = mt.SynchronousMotorSignalInjectionCtrlPars(
     T_s=250e-6,

--- a/examples/two_mass_systems/plot_vector_ctrl_pmsm_2kw_two_mass.py
+++ b/examples/two_mass_systems/plot_vector_ctrl_pmsm_2kw_two_mass.py
@@ -26,10 +26,10 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-mech = mt.MechanicsTwoMass(J_M=.005, J_L=.005, K_S=700, C_S=.01)  # C_S=.13
-motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDriveTwoMass(motor, mech, conv)
+mdl = mt.SynchronousMotorDriveTwoMass()
+mdl.mech = mt.MechanicsTwoMass(J_M=.005, J_L=.005, K_S=700, C_S=.01)  # C_S=.13
+mdl.motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Configure the control system.
@@ -64,15 +64,11 @@ mt.plot(sim, base=base)  # Plot results in per-unit values
 # %%
 # Plot the load speed and the twist angle.
 
-# Continuous-time data
-mdl = sim.mdl.data
-# Time span
 t_span = (0, 1.2)
-# Plot
 _, (ax1, ax2) = plt.subplots(2, 1, figsize=(8, 5))
-ax1.plot(mdl.t, mdl.w_M, label=r'$\omega_\mathrm{M}$')
-ax1.plot(mdl.t, mdl.w_L, label=r'$\omega_\mathrm{L}$')
-ax2.plot(mdl.t, mdl.theta_ML*180/np.pi)
+ax1.plot(sim.mdl.data.t, sim.mdl.data.w_M, label=r'$\omega_\mathrm{M}$')
+ax1.plot(sim.mdl.data.t, sim.mdl.data.w_L, label=r'$\omega_\mathrm{L}$')
+ax2.plot(sim.mdl.data.t, sim.mdl.data.theta_ML*180/np.pi)
 ax1.set_xlim(t_span)
 ax2.set_xlim(t_span)
 ax1.set_xticklabels([])
@@ -89,7 +85,7 @@ plt.show()
 f_span = (5, 500)
 num = 200
 # Parameters
-J_M, J_L, K_S, C_S = mech.J_M, mech.J_L, mech.K_S, mech.C_S
+J_M, J_L, K_S, C_S = mdl.mech.J_M, mdl.mech.J_L, mdl.mech.K_S, mdl.mech.C_S
 # Frequencies
 w = 2*np.pi*np.logspace(np.log10(f_span[0]), np.log10(f_span[-1]), num=num)
 s = 1j*w

--- a/examples/vector/plot_vector_ctrl_im_2kw.py
+++ b/examples/vector/plot_vector_ctrl_im_2kw.py
@@ -27,15 +27,14 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
+mdl = mt.InductionMotorDrive()
 # Configure the induction motor using its inverse-Γ parameters
-motor = mt.InductionMotorInvGamma(
+mdl.motor = mt.InductionMotorInvGamma(
     R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224, n_p=2)
+mdl.mech = mt.Mechanics(J=.015)  # Mechanics model
+mdl.conv = mt.Inverter(u_dc=540)  # Inverter model
 # Alternatively configure the induction motor using its Γ parameters
-# motor = mt.InductionMotor(R_s=3.7, R_r=2.5, L_ell=.023, L_s=.245, n_p=2)
-
-mech = mt.Mechanics(J=.015)  # Mechanics model
-conv = mt.Inverter(u_dc=540)  # Inverter model
-mdl = mt.InductionMotorDrive(motor, mech, conv)  # System model
+# mdl.motor = mt.InductionMotor(R_s=3.7, R_r=2.5, L_ell=.023, L_s=.245, n_p=2)
 
 # %%
 # Configure the control system. You may also try to change the parameters.

--- a/examples/vector/plot_vector_ctrl_pmsm_2kw.py
+++ b/examples/vector/plot_vector_ctrl_pmsm_2kw.py
@@ -21,10 +21,10 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Configure the control system.

--- a/examples/vector/plot_vector_ctrl_pmsyrm_thor.py
+++ b/examples/vector/plot_vector_ctrl_pmsyrm_thor.py
@@ -23,10 +23,10 @@ base = mt.BaseValues(
 # Configure the system model.
 
 # Configure magnetically linear motor model
-motor = mt.SynchronousMotor(n_p=2, R_s=.2, L_d=4e-3, L_q=17e-3, psi_f=.134)
-mech = mt.Mechanics(J=.0042)
-conv = mt.Inverter(u_dc=310)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotor(n_p=2, R_s=.2, L_d=4e-3, L_q=17e-3, psi_f=.134)
+mdl.mech = mt.Mechanics(J=.0042)
+mdl.conv = mt.Inverter(u_dc=310)
 
 # %%
 # Configure the control system.

--- a/examples/vector/plot_vector_ctrl_syrm_7kw.py
+++ b/examples/vector/plot_vector_ctrl_syrm_7kw.py
@@ -21,10 +21,11 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor(n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotor(
+    n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Configure the control system. You may also try to change the parameters.

--- a/examples/vhz/plot_obs_vhz_ctrl_im_2kw.py
+++ b/examples/vhz/plot_obs_vhz_ctrl_im_2kw.py
@@ -28,11 +28,11 @@ base = mt.BaseValues(
 # Configure the system model.
 
 # Configure the induction motor using its inverse-Γ parameters
-motor = mt.InductionMotorInvGamma(
+mdl = mt.InductionMotorDrive()
+mdl.motor = mt.InductionMotorInvGamma(
     R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224, n_p=2)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.InductionMotorDrive(motor, mech, conv)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Configure the control system.

--- a/examples/vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
+++ b/examples/vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
@@ -21,10 +21,10 @@ base = mt.BaseValues(
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotor(n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Configure the control system.

--- a/examples/vhz/plot_obs_vhz_ctrl_syrm_7kw.py
+++ b/examples/vhz/plot_obs_vhz_ctrl_syrm_7kw.py
@@ -74,13 +74,12 @@ def i_s(psi_s):
 # %%
 # Configure the system model.
 
-motor = mt.SynchronousMotorSaturated(n_p=2, R_s=.54, current=i_s)
-
-# Magnetically linear SyRM model
-# motor = mt.SynchronousMotor(p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
-mech = mt.Mechanics(J=.015)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.SynchronousMotorDrive(motor, mech, conv)
+mdl = mt.SynchronousMotorDrive()
+mdl.motor = mt.SynchronousMotorSaturated(n_p=2, R_s=.54, current=i_s)
+mdl.mech = mt.Mechanics(J=.015)
+mdl.conv = mt.Inverter(u_dc=540)
+# Magnetically linear SyRM model for comparison
+# mdl.motor = mt.SynchronousMotor(p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
 
 # %%
 # Configure the control system.

--- a/examples/vhz/plot_vhz_ctrl_6step_im_2kw.py
+++ b/examples/vhz/plot_vhz_ctrl_6step_im_2kw.py
@@ -25,13 +25,11 @@ base = mt.BaseValues(
 # %%
 # Create the system model.
 
-# Configure the induction motor using its inverse-Γ parameters
-motor = mt.InductionMotorInvGamma(
+mdl = mt.InductionMotorDrive()
+mdl.motor = mt.InductionMotorInvGamma(
     R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224, n_p=2)
-
-mech = mt.Mechanics(J=.016)
-conv = mt.Inverter(u_dc=540)
-mdl = mt.InductionMotorDrive(motor, mech, conv)
+mdl.mech = mt.Mechanics(J=.016)
+mdl.conv = mt.Inverter(u_dc=540)
 
 # %%
 # Control system (parametrized as open-loop V/Hz control).

--- a/examples/vhz/plot_vhz_ctrl_im_2kw.py
+++ b/examples/vhz/plot_vhz_ctrl_im_2kw.py
@@ -50,15 +50,14 @@ def L_s(psi):
 # %%
 # Create the system model.
 
+mdl = mt.InductionMotorDriveDiode()
 # Γ-equivalent motor model with main-flux saturation included
-motor = mt.InductionMotorSaturated(
+mdl.motor = mt.InductionMotorSaturated(
     n_p=2, R_s=3.7, R_r=2.5, L_ell=.023, L_s=L_s)
 # Mechanics model
-mech = mt.Mechanics(J=.015)
+mdl.mech = mt.Mechanics(J=.015)
 # Frequency converter with a diode bridge
-conv = mt.FrequencyConverter(L=2e-3, C=235e-6, U_g=400, f_g=50)
-# Collect the system model
-mdl = mt.InductionMotorDriveDiode(motor, mech, conv)
+mdl.conv = mt.FrequencyConverter(L=2e-3, C=235e-6, U_g=400, f_g=50)
 
 # %%
 # Control system (parametrized as open-loop V/Hz control).


### PR DESCRIPTION
The electrical angle of the rotor theta_m was added as a state variable in the SynchronousMotor class. This allows to decouple this class from the Mechanics class, i.e., the private copy of the mechanics model SynchronousMotor._mech is deleted in this PR (this was needed to get the electrical rotor angle motor.n_p*mech.theta_M for the internal coordinate transformation in the SynchronousMotor class).

Furthermore, the examples were refactored so that unnecessary instances of the model subsystems (motor, mech, conv) are not created, but they are directly instantiated as attributes of mdl. However, if desired, the earlier parametrization approach can still be used.  