### PR TITLE
Fix clock reset.

### DIFF
--- a/motulator/control/_common.py
+++ b/motulator/control/_common.py
@@ -472,7 +472,7 @@ class Clock:
             Sampling period (s).
 
         """
-        self.t += T_s if self.t < self.t_reset else 0
+        self.t = (self.t + T_s) % self.t_reset
 
 
 # %%


### PR DESCRIPTION
In `control._common.Clock()`, the clock is not reset after hitting the reset time `t_reset`, it only stops updating. In this fix, if the updated clock time is `t_reset`, the clock is reset to zero. If if overshoots `t_reset` by `dt`, the clock is set to `dt`.