### PR TITLE
Fix RateLimiter call method docstring.

### DIFF
--- a/motulator/control/_common.py
+++ b/motulator/control/_common.py
@@ -420,13 +420,13 @@ class RateLimiter:
 
         Parameters
         ----------
+        T_s : float
+            Sampling period (s).
         u : float
             Input signal.
 
         Returns
         -------
-        T_s : float
-            Sampling period (s).
         y : float
             Rate-limited output signal.
 


### PR DESCRIPTION
Minor docstring fix: The docstring of the `__call__()` method of `control._common.RateLimiter()` lists the parameter `T_s` as a return value. This fix moves it into the right place.