### PR TITLE
Fix observer when sensorless=False.

### DIFF
--- a/motulator/control/im/_observers.py
+++ b/motulator/control/im/_observers.py
@@ -73,7 +73,7 @@ class Observer:
         else:
             if self.k1 is None:
                 self.k1 = lambda w_m: 1 + .2*np.abs(w_m)/(self.alpha - 1j*w_m)
-            self.k2 = 0*self.k1
+            self.k2 = lambda w_m: 0
 
         # States
         self.psi_R, self.theta_s, self.w_m, self._i_s_old = 0, 0, 0, 0

--- a/motulator/control/sm/_observers.py
+++ b/motulator/control/sm/_observers.py
@@ -61,7 +61,8 @@ class Observer:
         else:
             if self.k1 is None:
                 self.k1 = lambda w_m: 2*np.pi*15
-            self.k2 = 0*self.k1
+            self.k2 = lambda w_m: 0
+            
         # Initial states
         self.theta_m, self.w_m, self.psi_s = 0, 0, par.psi_f
 


### PR DESCRIPTION
Fixes a bug in setting the observer gain in `control.im._observers.Observer()` and `control.sm._observers.Observer()` when `sensorless=False`. The assignment `self.k2 = 0*self.k1` fails because `self.k1` is a callable. This is fixed by setting `self.k2 = lambda w_m: 0`. `self.k2` now always returns zero.