### PR TITLE
Replace the minimum-phase-error overmodulation method with the minimum-amplitude-error overmodulation method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,19 @@
 {
+    "editor.rulers": [
+        80
+    ],
     "editor.formatOnType": false,
     "editor.formatOnSave": true,
-    "python.formatting.provider": "yapf",
-    "python.formatting.yapfArgs": [
+    "editor.formatOnSaveMode": "file",
+    "editor.defaultFormatter": "eeyore.yapf",
+    "yapf.args": [
         "--style",
         "{based_on_style: pep8, indent_width: 4, column_limit: 79, no_spaces_around_selected_binary_operators: '*,/', split_before_first_argument: true, coalesce_brackets: true, spaces_before_comment: 2}"
     ],
+    "pylint.ignorePatterns": [
+        "**/site-packages/**/*.py",
+        ".vscode/*.py",
+        "docs/*"
+    ],
+    "esbonio.sphinx.confDir": "${workspaceFolder}/docs/source"
 }


### PR DESCRIPTION
This pull request replaces the minimum-phase-error overmodulation method with the minimum-amplitude-error overmodulation method in the PWM class. The latter is slightly simpler and is documented to provide some performance gain when used with closed-loop current control. 

Furthermore, the formatting and linting settings for VSCode have been updated (see https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions).