### PR TITLE
Delete duplicate target names in literature references in docstrings

### DIFF
--- a/motulator/control/_common.py
+++ b/motulator/control/_common.py
@@ -104,8 +104,8 @@ class PWM:
         """
         Compute the duty ratios for three-phase space-vector PWM.
 
-        This computes the duty ratios corresponding to standard space-vector 
-        PWM and minimum-amplitude-error overmodulation [#Hav1999]_.
+        This computes the duty ratios corresponding to standard space-vector PWM 
+        and minimum-amplitude-error overmodulation [#Hav1999]_.
 
         Parameters
         ----------

--- a/motulator/control/im/_observers.py
+++ b/motulator/control/im/_observers.py
@@ -151,8 +151,8 @@ class FullOrderObserver:
     Full-order flux observer for induction machines in estimated 
     rotor flux coordinates.
 
-    This class implements a full-order flux observer for induction machines.
-    The observer structure is similar to [#Tii2023]_. The observer operates in 
+    This class implements a full-order flux observer for induction machines. The 
+    observer structure is similar to [#Tii2023]_. The observer operates in 
     estimated rotor flux coordinates. 
     
     Parameters
@@ -273,8 +273,8 @@ class FullOrderObserver:
         i_s : complex
             Stator current (A) in estimated rotor flux coordinates.
         w_m : float, optional
-            Rotor angular speed (electrical rad/s). This signal is not used
-            and only exists for compatibility.
+            Rotor angular speed (electrical rad/s). This signal is not used and 
+            only exists for compatibility.
 
         Returns
         -------

--- a/motulator/control/sm/_flux_vector.py
+++ b/motulator/control/sm/_flux_vector.py
@@ -17,7 +17,7 @@ class FluxVectorCtrl(Ctrl):
 
     This class implements a variant of stator-flux-vector control [#Pel2009]_. 
     Rotor coordinates as well as decoupling between the stator flux and torque 
-    channels are used according to [#Awa2019]_. Here, the stator flux magnitude 
+    channels are used according to [#Awa2019b]_. Here, the stator flux magnitude 
     and the electromagnetic torque are selected as controllable variables. 
 
     Notes
@@ -60,9 +60,9 @@ class FluxVectorCtrl(Ctrl):
        region,” IEEE Trans.Ind. Appl., 2009, 
        https://doi.org/10.1109/TIA.2009.2027167
 
-    .. [#Awa2019] Awan, Hinkkanen, Bojoi, Pellegrino, "Stator-flux-oriented 
-       control of synchronous motors: A systematic design procedure," IEEE Trans. 
-       Ind. Appl., 2019, https://doi.org/10.1109/TIA.2019.2927316
+    .. [#Awa2019b] Awan, Hinkkanen, Bojoi, Pellegrino, "Stator-flux-oriented 
+       control of synchronous motors: A systematic design procedure," IEEE 
+       Trans. Ind. Appl., 2019, https://doi.org/10.1109/TIA.2019.2927316
 
     """
 

--- a/motulator/control/sm/_obs_vhz.py
+++ b/motulator/control/sm/_obs_vhz.py
@@ -72,8 +72,7 @@ class ObserverBasedVHzCtrl(Ctrl):
     ----------
     .. [#Tii2022] Tiitinen, Hinkkanen, Kukkola, Routimo, Pellegrino, Harnefors, 
        "Stable and passive observer-based V/Hz control for synchronous Motors," 
-       Proc. IEEE ECCE, Detroit, MI, Oct. 2022, 
-       https://doi.org/10.1109/ECCE50734.2022.9947858
+       Proc. IEEE ECCE, 2022, https://doi.org/10.1109/ECCE50734.2022.9947858
 
     """
 

--- a/motulator/control/sm/_observers.py
+++ b/motulator/control/sm/_observers.py
@@ -144,12 +144,6 @@ class FluxObserver:
     psi_s : complex
         Stator flux estimate (Vs).
   
-    References
-    ----------
-    .. [#Tii2022] Tiitinen, Hinkkanen, Kukkola, Routimo, Pellegrino, Harnefors, 
-       "Stable and passive observer-based V/Hz control for synchronous Motors," 
-       Proc. IEEE ECCE, 2022, https://doi.org/10.1109/ECCE50734.2022.9947858
-
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/motulator/control/sm/_vector.py
+++ b/motulator/control/sm/_vector.py
@@ -44,8 +44,8 @@ class VectorCtrl(Ctrl):
     """
     Vector control for synchronous machine drives.
 
-    This class interconnects the subsystems of the control system and
-    provides the interface to the solver.
+    This class interconnects the subsystems of the control system and provides 
+    the interface to the solver.
 
     Parameters
     ----------
@@ -166,7 +166,7 @@ class CurrentCtrl(ComplexPICtrl):
     Current controller for synchronous machines.
 
     This provides an interface of a current controller for synchronous machines
-    [#Awa2019]_. The gains are initialized based on the desired closed-loop 
+    [#Awa2019a]_. The gains are initialized based on the desired closed-loop 
     bandwidth and the inductances. 
 
     Parameters
@@ -178,7 +178,7 @@ class CurrentCtrl(ComplexPICtrl):
 
     References
     ----------
-    .. [#Awa2019] Awan, Saarakkala, Hinkkanen, "Flux-linkage-based current 
+    .. [#Awa2019a] Awan, Saarakkala, Hinkkanen, "Flux-linkage-based current 
        control of saturated synchronous motors," IEEE Trans. Ind. Appl. 2019,
        https://doi.org/10.1109/TIA.2019.2919258
 
@@ -226,9 +226,9 @@ class CurrentReferencePars:
     Attributes
     ----------
     i_sd_mtpa : callable
-        MTPA d-axis current (A) as a funtion of the torque (Nm).
+        MTPA d-axis current (A) as a function of the torque (Nm).
     tau_M_lim : callable
-        Torque limite (Nm) as a function of the stator flux linkage (Vs). This
+        Torque limit (Nm) as a function of the stator flux linkage (Vs). This
         limit merges the MTPV and current limits.
     i_sd_lim : callable
         d-axis current limit (A) as a function of the stator flux linkage (Vs).


### PR DESCRIPTION
Delete duplicate target names in literature references in docstrings. Duplicate target names are preferably avoided since the Sphinx AutoAPI extension is used to automatically generate API based docstrings.