### PR TITLE
Refactoring, a diode bridge model for SM drives

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.rulers": [
-        80
+        79
     ],
     "editor.formatOnType": false,
     "editor.formatOnSave": true,

--- a/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
+++ b/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
@@ -46,7 +46,7 @@ mdl.mechanics.tau_L_t = lambda t: (t > .8)*base.tau_nom*.7
 # %%
 # Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=1.6)
 
 # %%

--- a/examples/flux_vector/plot_flux_vector_syrm_7kw.py
+++ b/examples/flux_vector/plot_flux_vector_syrm_7kw.py
@@ -80,7 +80,7 @@ mdl.mechanics.tau_L_t = Sequence(times, values)
 # %%
 # Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=4)
 
 # %%

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_im_2kw.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_im_2kw.py
@@ -60,11 +60,9 @@ mdl.mechanics.tau_L_t = Sequence(times, values)
 # mdl.mech.tau_L_w = lambda w_M: np.sign(w_M)*k*w_M**2
 
 # %%
-# Create the simulation object and simulate it. You can also enable the PWM
-# model (which makes simulation slower). One-sampling-period computational
-# delay is modeled.
+# Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False, delay=1)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=4)
 
 # %%

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
@@ -49,11 +49,9 @@ values = np.array([0, 0, 1, 1, 0, 0])*base.tau_nom
 mdl.mechanics.tau_L_t = Sequence(times, values)
 
 # %%
-# Create the simulation object and simulate it. You can also enable the PWM
-# model (which makes simulation slower). One-sampling-period computational
-# delay is modeled.
+# Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False, delay=1)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=8)
 
 # %%

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw_two_mass.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw_two_mass.py
@@ -5,8 +5,8 @@
 This example simulates observer-based V/Hz control of a 2.2-kW PMSM drive. The
 mechanical subsystem is modeled as a two-mass system. The resonance frequency
 of the mechanics is around 85 Hz. The mechanical parameters correspond to 
-[#Saa2015]_, except that the torsional damping is set to a smaller value in this 
-example.
+[#Saa2015]_, except that the torsional damping is set to a smaller value in 
+this example.
 
 """
 
@@ -57,7 +57,7 @@ mdl.mechanics.tau_L_t = Sequence(times, values)
 # %%
 # Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=1.2)
 # sphinx_gallery_thumbnail_number = 3
 plot(sim, base)  # Plot results in per-unit values

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_pmsyrm_thor.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_pmsyrm_thor.py
@@ -118,11 +118,9 @@ mdl.mechanics.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
 # mdl.mechanics.tau_L_t = Sequence(times, values)
 
 # %%
-# Create the simulation object and simulate it. You can also enable the PWM
-# model (which makes simulation slower). One-sampling-period computational
-# delay is modeled.
+# Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False, delay=1)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=8)
 
 # %%

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_syrm_7kw.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_syrm_7kw.py
@@ -27,8 +27,8 @@ base = BaseValues(
 # but the same model structure can also be used for other synchronous motors.
 # For PM motors, the magnetomotive force (MMF) of the PMs can be modeled using
 # constant current source `i_f` on the d-axis [#Awa2018]_, [#Jah1986]_.
-# Correspondingly, this approach assumes that the MMFs of the d-axis current and
-# of the PMs are in series. This model cannot capture the desaturation
+# Correspondingly, this approach assumes that the MMFs of the d-axis current
+# and of the PMs are in series. This model cannot capture the desaturation
 # phenomenon of thin iron ribs, see [#Arm2009]_ for details. For such motors,
 # look-up tables can be used.
 
@@ -104,11 +104,9 @@ values = np.array([0, 0, 1, 1, 0, 0])*base.tau_nom
 mdl.mechanics.tau_L_t = Sequence(times, values)
 
 # %%
-# Create the simulation object and simulate it. You can also enable the PWM
-# model (which makes simulation slower). One-sampling-period computational
-# delay is modeled.
+# Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False, delay=1)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=8)
 
 # %%

--- a/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
+++ b/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
@@ -54,7 +54,7 @@ mdl.mechanics.tau_L_t = Sequence(times, values)
 # %%
 # Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=4)
 
 # %%

--- a/examples/signal_inj/plot_signal_inj_syrm_7kw.py
+++ b/examples/signal_inj/plot_signal_inj_syrm_7kw.py
@@ -46,7 +46,7 @@ ctrl = control.sm.SignalInjectionCtrl(par, ref, T_s=250e-6)
 
 # Speed reference
 times = np.array([0, .25, .25, .375, .5, .625, .75, .75, 1])*4
-values = np.array([0, 0, 1, 1, 0, -1, -1, 0, 0])*base.w*.1
+values = np.array([0, 0, 1, 1, 0, -1, -1, 0, 0])*.1*base.w
 ctrl.w_m_ref = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
@@ -56,7 +56,7 @@ mdl.mechanics.tau_L_t = Sequence(times, values)
 # %%
 # Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=4)
 
 # %%

--- a/examples/vector/plot_vector_ctrl_im_2kw.py
+++ b/examples/vector/plot_vector_ctrl_im_2kw.py
@@ -31,7 +31,7 @@ base = BaseValues(
 
 def L_s(psi):
     """
-    Stator inductance saturation model for a 2.2-kW machine.
+    Stator inductance saturation model for a 2.2-kW induction machine.
 
     Parameters
     ----------
@@ -59,13 +59,15 @@ machine = model.im.InductionMachineSaturated(
     n_p=2, R_s=3.7, R_r=2.5, L_ell=.023, L_s=L_s)
 # Unsaturated machine model, using its inverse-Γ parameters (uncomment to try)
 # machine = model.im.InductionMachineInvGamma(
-#    R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224, n_p=2)
+#    n_p=2, R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224)
 # Alternatively, configure the machine model using its Γ parameters
 # machine = model.im.InductionMachine(
-#     R_s=3.7, R_r=2.5, L_ell=.023, L_s=.245, n_p=2)
+#     n_p=2, R_s=3.7, R_r=2.5, L_ell=.023, L_s=.245)
 mechanics = model.Mechanics(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.im.Drive(machine, mechanics, converter)
+# mdl.pwm = model.CarrierComparison()  # Try to enable the PWM model
+# mdl.delay = model.Delay(2)  # Try longer computational delay
 
 # %%
 # Configure the control system.
@@ -94,22 +96,11 @@ mdl.mechanics.tau_L_t = lambda t: (t > .75)*base.tau_nom
 # ctrl.w_m_ref = lambda t: (t > .2)*(2*base.w)
 # mdl.mechanics.tau_L_t = lambda t: 0
 
-# Speed reversals under the rated load (uncomment to try, change t_stop=8 below)
-# import numpy as np
-# from motulator.helpers import Sequence
-# times = np.array([0, .125, .25, .375, .5, .625, .75, .875, 1])*8
-# values = np.array([0, 0, 1, 1, 0, -1, -1, 0, 0])*base.w
-# ctrl.w_m_ref = Sequence(times, values)
-# # External load torque
-# times = np.array([0, .125, .125, .875, .875, 1])*8
-# values = np.array([0, 0, 1, 1, 0, 0])*base.tau_nom
-# mdl.mechanics.tau_L_t = Sequence(times, values)
-
 # %%
 # Create the simulation object and simulate it. You can also enable the PWM
 # model (which makes simulation slower).
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=1.5)
 
 # %%

--- a/examples/vector/plot_vector_ctrl_pmsm_2kw_diode.py
+++ b/examples/vector/plot_vector_ctrl_pmsm_2kw_diode.py
@@ -2,7 +2,8 @@
 2.2-kW PMSM, diode bridge
 =========================
 
-This example simulates sensorless vector control of a 2.2-kW PMSM drive. 
+This example simulates sensorless vector control of a 2.2-kW PMSM drive, 
+equipped with a diode bridge rectifier. 
 
 """
 
@@ -10,7 +11,7 @@ This example simulates sensorless vector control of a 2.2-kW PMSM drive.
 # Imports.
 
 from motulator import model, control
-from motulator import BaseValues, plot
+from motulator import BaseValues, plot, plot_extra
 
 # %%
 # Compute base values based on the nominal values (just for figures).
@@ -24,9 +25,9 @@ base = BaseValues(
 machine = model.sm.SynchronousMachine(
     n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 mechanics = model.Mechanics(J=.015)
-converter = model.Inverter(u_dc=540)
-mdl = model.sm.Drive(machine, mechanics, converter)
-# mdl.pwm = model.CarrierComparison()  # Enable the PWM model
+converter = model.FrequencyConverter(L=2e-3, C=235e-6, U_g=400, f_g=50)
+mdl = model.sm.DriveWithDiodeBridge(machine, mechanics, converter)
+mdl.pwm = model.CarrierComparison()  # Enable the PWM model
 
 # %%
 # Configure the control system.
@@ -40,15 +41,18 @@ ctrl = control.sm.VectorCtrl(par, ref, T_s=250e-6, sensorless=True)
 # Set the speed reference and the external load torque.
 
 # Speed reference
-ctrl.w_m_ref = lambda t: (t > .2)*2*base.w
+ctrl.w_m_ref = lambda t: (t > .2)*base.w
 
 # External load torque
-mdl.mechanics.tau_L_t = lambda t: (t > .8)*.7*base.tau_nom
+mdl.mechanics.tau_L_t = lambda t: (t > .6)*base.tau_nom
 
 # %%
 # Create the simulation object and simulate it.
 
-# Simulate the system and plot results in per-unit values
+# Simulate the system
 sim = model.Simulation(mdl, ctrl)
-sim.simulate(t_stop=1.4)
+sim.simulate(t_stop=1)
+
+# Plot results in per-unit values
 plot(sim, base)
+plot_extra(sim, base, t_span=(.8, .825))

--- a/examples/vector/plot_vector_ctrl_pmsyrm_thor.py
+++ b/examples/vector/plot_vector_ctrl_pmsyrm_thor.py
@@ -62,12 +62,8 @@ k = .05*base.tau_nom/(base.w/base.n_p)**2
 mdl.mechanics.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
 
 # %%
-# Create the simulation object and simulate it.
+# Create the simulation object, simulate, and plot results in per-unit values.
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=.6)
-
-# %%
-# Plot results in per-unit values.
-
 plot(sim, base)

--- a/examples/vector/plot_vector_ctrl_syrm_7kw.py
+++ b/examples/vector/plot_vector_ctrl_syrm_7kw.py
@@ -50,12 +50,8 @@ values = np.array([0, 0, 1, 1, 0, 0])*base.tau_nom
 mdl.mechanics.tau_L_t = Sequence(times, values)
 
 # %%
-# Create the simulation object and simulate it.
+# Create the simulation object, simulate, and plot results in per-unit values.
 
-sim = model.Simulation(mdl, ctrl, pwm=False)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=4)
-
-# %%
-# Plot results in per-unit values.
-
 plot(sim, base)

--- a/examples/vhz/plot_vhz_ctrl_6step_im_2kw.py
+++ b/examples/vhz/plot_vhz_ctrl_6step_im_2kw.py
@@ -31,6 +31,7 @@ machine = model.im.InductionMachineInvGamma(
 mechanics = model.Mechanics(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.im.Drive(machine, mechanics, converter)
+mdl.pwm = model.CarrierComparison()  # Enable the PWM model
 
 # %%
 # Control system (parametrized as open-loop V/Hz control).
@@ -46,7 +47,7 @@ ctrl.rate_limiter = control.RateLimiter(2*np.pi*120)
 
 # Speed reference
 times = np.array([0, .1, .3, 1])*2
-values = np.array([0, 0, 1, 1])*base.w*2
+values = np.array([0, 0, 1, 1])*2*base.w
 ctrl.w_m_ref = Sequence(times, values)
 
 # Quadratic load torque profile (corresponding to pumps and fans)
@@ -56,10 +57,9 @@ mdl.mechanics.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
 mdl.mechanics.tau_L_t = lambda t: (t > 1.)*base.tau_nom*0
 
 # %%
-# Create the simulation object and simulate it. The option ``pwm=True`` enables
-# the model for the carrier comparison.
+# Create the simulation object and simulate it.
 
-sim = model.Simulation(mdl, ctrl, pwm=True)
+sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=2)
 
 # %%

--- a/motulator/__init__.py
+++ b/motulator/__init__.py
@@ -3,7 +3,7 @@
 
 This software includes continuous-time simulation models for induction machines 
 and synchronous machines. Furthermore, selected examples of discrete-time 
-control algortihms are also included as well as various utilities.
+control algorithms are also included as well as various utilities.
 
 """
 

--- a/motulator/_helpers.py
+++ b/motulator/_helpers.py
@@ -194,3 +194,23 @@ class Step:
 
         """
         return self.initial_value + (t >= self.step_time)*self.step_value
+
+
+# %%
+def wrap(theta):
+    """
+    Limit the angle into the range [-pi, pi).
+
+    Parameters
+    ----------
+    theta : float
+        Angle (rad).
+
+    Returns
+    -------
+    float
+        Limited angle.
+
+    """
+
+    return np.mod(theta + np.pi, 2*np.pi) - np.pi

--- a/motulator/control/_common.py
+++ b/motulator/control/_common.py
@@ -67,9 +67,9 @@ class PWM:
 
         References
         ----------
-        .. [#Bol1997] Bolognani, Zigliotto, "Novel digital continuous control of 
-           SVM inverters in the overmodulation range," IEEE Trans. Ind. Appl.,
-           1997, https://doi.org/10.1109/28.568019
+        .. [#Bol1997] Bolognani, Zigliotto, "Novel digital continuous control 
+           of SVM inverters in the overmodulation range," IEEE Trans. Ind. 
+           Appl., 1997, https://doi.org/10.1109/28.568019
 
         """
         # Limited magnitude
@@ -104,8 +104,8 @@ class PWM:
         """
         Compute the duty ratios for three-phase space-vector PWM.
 
-        This computes the duty ratios corresponding to standard space-vector PWM 
-        and minimum-amplitude-error overmodulation [#Hav1999]_.
+        This computes the duty ratios corresponding to standard space-vector 
+        PWM and minimum-amplitude-error overmodulation [#Hav1999]_.
 
         Parameters
         ----------
@@ -202,14 +202,14 @@ class PICtrl:
 
     where `u` is the controller output, `y_ref` is the reference signal, `y` is
     the feedback signal, and `1/s` refers to integration. The standard PI
-    controller is obtained by choosing ``k_t = k_p``. The integrator anti-windup 
-    is implemented based on the realized controller output.
+    controller is obtained by choosing ``k_t = k_p``. The integrator 
+    anti-windup is implemented based on the realized controller output.
 
     Notes
     -----
     This controller can be used, e.g., as a speed controller. In this case, `y` 
-    corresponds to the rotor angular speed `w_M` and `u` to the torque reference 
-    `tau_M_ref`.
+    corresponds to the rotor angular speed `w_M` and `u` to the torque 
+    reference `tau_M_ref`.
 
     Parameters
     ----------
@@ -289,7 +289,7 @@ class SpeedCtrl(PICtrl):
     """
     2DOF PI speed controller.
 
-    This provides an interface for a speed controller. The gains are initialized
+    This is an interface for a speed controller. The gains are initialized 
     based on the desired closed-loop bandwidth and the rotor inertia estimate.
 
     Parameters
@@ -322,10 +322,10 @@ class ComplexPICtrl:
 
     where `u` is the controller output, `i_ref` is the reference signal, `i` is
     the feedback signal, `w` is the angular speed of synchronous coordinates, 
-    and `1/s` refers to integration. This algorithm is compatible with both real 
-    and complex signals. The 1DOF version is obtained by setting ``k_t = k_p``. 
-    The integrator anti-windup is implemented based on the realized controller 
-    output.
+    and `1/s` refers to integration. This algorithm is compatible with both 
+    real and complex signals. The 1DOF version is obtained by setting 
+    ``k_t = k_p``. The integrator anti-windup is implemented based on the 
+    realized controller output.
 
     Parameters
     ----------
@@ -486,7 +486,7 @@ class Clock:
 
 # %%
 class Ctrl:
-    """Base class for the control system."""
+    """Base class for control systems."""
 
     def __init__(self):
         self.clear()
@@ -507,9 +507,9 @@ class Ctrl:
         """
         Run the main control loop.
 
-        The main control loop is callable that returns the sampling period `T_s` 
-        (float) and the duty ratios `d_abc` (ndarray, shape (3,)) for the next 
-        sampling period.
+        The main control loop is callable that returns the sampling period 
+        `T_s` (float) and the duty ratios `d_abc` (ndarray, shape (3,)) for the 
+        next sampling period.
 
         Parameters
         ----------

--- a/motulator/control/im/_obs_vhz.py
+++ b/motulator/control/im/_obs_vhz.py
@@ -1,15 +1,15 @@
 """
 Observer-based V/Hz control for induction machine drives.
 
-This implements the observer-based V/Hz control method described in [#Tii2022]_. 
-The state-feedback control law is in the alternative form which uses an
+This implements the observer-based V/Hz control method [#Tii2022]_. The 
+state-feedback control law is in the alternative form which uses an 
 intermediate stator current reference.
 
 References
 ----------
-.. [#Tii2022] Tiitinen, Hinkkanen, Harnefors, "Stable and passive observer-based 
-   V/Hz control for induction motors," Proc. IEEE ECCE, Detroit, MI, Oct. 2022,
-   https://doi.org/10.1109/ECCE50734.2022.9948057
+.. [#Tii2022] Tiitinen, Hinkkanen, Harnefors, "Stable and passive 
+   observer-based V/Hz control for induction motors," Proc. IEEE ECCE, Detroit, 
+   MI, Oct. 2022, https://doi.org/10.1109/ECCE50734.2022.9948057
 
 """
 

--- a/motulator/control/im/_observers.py
+++ b/motulator/control/im/_observers.py
@@ -10,9 +10,9 @@ class Observer:
     rotor flux coordinates.
 
     This class implements a reduced-order flux observer for induction machines.
-    Both sensored and sensorless operation are supported. The observer structure
-    is similar to [#Hin2010]_. The observer operates in estimated rotor flux 
-    coordinates. 
+    Both sensored and sensorless operation are supported. The observer 
+    structure is similar to [#Hin2010]_. The observer operates in estimated 
+    rotor flux coordinates. 
     
     Parameters
     ----------
@@ -151,8 +151,8 @@ class FullOrderObserver:
     Full-order flux observer for induction machines in estimated 
     rotor flux coordinates.
 
-    This class implements a full-order flux observer for induction machines. The 
-    observer structure is similar to [#Tii2023]_. The observer operates in 
+    This class implements a full-order flux observer for induction machines. 
+    The observer structure is similar to [#Tii2023]_. The observer operates in 
     estimated rotor flux coordinates. 
     
     Parameters
@@ -184,8 +184,8 @@ class FullOrderObserver:
     References
     ----------
     .. [#Tii2023] Tiitinen, Hinkkanen, Harnefors, "Speed-adaptive full-order 
-       observer revisited: Closed-form design for induction motor drives," Proc. 
-       IEEE SLED, 2023, https://doi.org/10.1109/SLED57582.2023.10261359
+       observer revisited: Closed-form design for induction motor drives," 
+       Proc. IEEE SLED, 2023, https://doi.org/10.1109/SLED57582.2023.10261359
 
     """
 

--- a/motulator/control/im/_vector.py
+++ b/motulator/control/im/_vector.py
@@ -196,8 +196,8 @@ class CurrentReferencePars:
     Parameters for reference generation.
 
     This dataclass stores the nominal and limit values needed for reference 
-    generation. For calculating the rotor flux reference, the machine parameters 
-    are also required.
+    generation. For calculating the rotor flux reference, the machine 
+    parameters are also required.
 
     Parameters
     ----------
@@ -240,8 +240,8 @@ class CurrentReference:
     """
     Current reference generation.
 
-    In the base-speed region, the current reference in rotor-flux coordinates is
-    given by::
+    In the base-speed region, the current reference in rotor-flux coordinates 
+    is given by::
 
         i_s_ref = psi_R_nom/L_M + 1j*tau_M_ref/(1.5*n_p*abs(psi_R))
 

--- a/motulator/control/sm/_flux_vector.py
+++ b/motulator/control/sm/_flux_vector.py
@@ -17,13 +17,14 @@ class FluxVectorCtrl(Ctrl):
 
     This class implements a variant of stator-flux-vector control [#Pel2009]_. 
     Rotor coordinates as well as decoupling between the stator flux and torque 
-    channels are used according to [#Awa2019b]_. Here, the stator flux magnitude 
-    and the electromagnetic torque are selected as controllable variables. 
+    channels are used according to [#Awa2019b]_. Here, the stator flux 
+    magnitude and the electromagnetic torque are selected as controllable 
+    variables. 
 
     Notes
     -----
-    Proportional controllers are used for simplicity. The magnetic saturation is 
-    not considered in this implementation.
+    Proportional controllers are used for simplicity. The magnetic saturation 
+    is not considered in this implementation.
 
     Parameters
     ----------
@@ -48,7 +49,7 @@ class FluxVectorCtrl(Ctrl):
         Flux and torque reference generator.
     speed_ctrl : SpeedCtrl
         Speed controller.
-    w_m_ref : float
+    w_m_ref : callable
         Speed reference (electrical rad/s) as a function of time (s).
     pwm : PWM
         Pulse-width modulation.
@@ -144,7 +145,7 @@ class FluxVectorCtrl(Ctrl):
         # Auxiliary current
         i_a = psi_s.real/self.L_q + 1j*psi_s.imag/self.L_d - i_s
 
-        # Torque-production factor (c_tau = 0 corresponds to the MTPV condition)
+        # Torque-production factor, c_tau = 0 corresponds to the MTPV condition
         c_tau = 1.5*self.n_p*np.real(i_a*np.conj(psi_s))
 
         # References for the flux and torque controllers

--- a/motulator/control/sm/_observers.py
+++ b/motulator/control/sm/_observers.py
@@ -139,8 +139,8 @@ class FluxObserver:
     Attributes
     ----------
     delta : float
-        Angle estimate of the coordinate system with respect
-        to the d-axis of the rotor (electrical rad).
+        Angle estimate of the coordinate system with respect to the d-axis of 
+        the rotor (electrical rad).
     psi_s : complex
         Stator flux estimate (Vs).
   

--- a/motulator/control/sm/_torque.py
+++ b/motulator/control/sm/_torque.py
@@ -1,10 +1,10 @@
 """
 Torque characteristics for synchronous machines.
 
-This contains computation and plotting of torque characteristics for synchronous 
-machines, including the MTPA and MTPV loci [#Mor1990]_. The methods can be used 
-to define look-up tables for control and to analyze the characteristics. This 
-version omits the magnetic saturation.
+This contains computation and plotting of torque characteristics for 
+synchronous machines, including the MTPA and MTPV loci [#Mor1990]_. The methods 
+can be used to define look-up tables for control and to analyze the 
+characteristics. This version omits the magnetic saturation.
 
 References
 ----------
@@ -232,7 +232,8 @@ class TorqueCharacteristics:
         Parameters
         ----------
         i_s_max : float
-            Maximum stator current magnitude (A) at which the locus is computed.
+            Maximum stator current magnitude (A) at which the locus is 
+            computed.
         psi_s_min : float, optional
             Minimum stator flux magnitude (Vs) at which the locus is computed.
         N : int, optional
@@ -295,7 +296,8 @@ class TorqueCharacteristics:
             Maximum stator flux magnitude (Vs) at which the locus is computed. 
             Either `psi_s_max` or `i_s_max` must be given.
         i_s_max : float, optional
-            Maximum stator current magnitude (A) at which the locus is computed.
+            Maximum stator current magnitude (A) at which the locus is 
+            computed.
         N : int, optional
             Amount of points. The default is 20.
 

--- a/motulator/model/__init__.py
+++ b/motulator/model/__init__.py
@@ -2,7 +2,8 @@
 
 from motulator.model._mechanics import Mechanics, MechanicsTwoMass
 from motulator.model._converter import FrequencyConverter, Inverter
-from motulator.model._simulation import CarrierComparison, Simulation
+from motulator.model._simulation import (
+    CarrierComparison, Simulation, Delay, zoh)
 
 import motulator.model.im as im
 import motulator.model.sm as sm
@@ -14,6 +15,8 @@ __all__ = [
     "Inverter",
     "CarrierComparison",
     "Simulation",
+    "Delay",
+    "zoh",
     "im",
     "sm",
 ]

--- a/motulator/model/_converter.py
+++ b/motulator/model/_converter.py
@@ -24,7 +24,6 @@ class Inverter:
 
     def __init__(self, u_dc):
         self.u_dc0 = u_dc
-        self.q = 0j  # Switching state vector
 
     @staticmethod
     def ac_voltage(q, u_dc):
@@ -114,8 +113,6 @@ class FrequencyConverter(Inverter):
         self.u_g = np.sqrt(2/3)*U_g
         # Grid angular frequeyncy
         self.w_g = 2*np.pi*f_g
-        # Switching state vector
-        self.q = 0j
 
     def grid_voltages(self, t):
         """

--- a/motulator/model/sm/__init__.py
+++ b/motulator/model/sm/__init__.py
@@ -2,6 +2,7 @@
 
 from motulator.model.sm._drive import (
     Drive,
+    DriveWithDiodeBridge,
     DriveTwoMassMechanics,
     SynchronousMachine,
     SynchronousMachineSaturated,
@@ -15,6 +16,7 @@ from motulator.model.sm._flux_maps import (
 
 __all__ = [
     "Drive",
+    "DriveWithDiodeBridge",
     "DriveTwoMassMechanics",
     "SynchronousMachine",
     "SynchronousMachineSaturated",


### PR DESCRIPTION
This pull request contains the following changes:

- Add a base class for continuous-time system models. 
- Move the states related to the computational delay from the Simulation class to the Model class. Furthermore, store the switching state in the Model class instead of the Converter class . 
- Add a wrap function to helpers to simplify limiting the angles between -pi and pi.
- Add the DriveWithDiodeBridge class for synchronous machine drives as well as a corresponding example.
- Some refactoring.