### PR TITLE
Include PM-flux disturbance estimation in sensorless control

### DIFF
--- a/examples/flux_vector/plot_flux_vector_pmsyrm_5kw.py
+++ b/examples/flux_vector/plot_flux_vector_pmsyrm_5kw.py
@@ -163,7 +163,7 @@ par = control.sm.ModelPars(
 ref = control.sm.FluxTorqueReferencePars(
     par, i_s_max=2*base.i, k_u=1, psi_s_max=base.psi)
 ctrl = control.sm.FluxVectorCtrl(par, ref, sensorless=True)
-# Select low speed-estimation bandwidth since the saturation is not considered
+# Select a lower speed-estimation bandwidth to mitigate the saturation effects
 ctrl.observer = control.sm.Observer(par, alpha_o=2*np.pi*40, sensorless=True)
 
 # %%

--- a/examples/flux_vector/plot_flux_vector_syrm_7kw.py
+++ b/examples/flux_vector/plot_flux_vector_syrm_7kw.py
@@ -1,10 +1,13 @@
 """
-6.7-kW SyRM, saturated
-======================
+6.7-kW SyRM, saturated, disturbance estimation
+==============================================
 
 This example simulates sensorless stator-flux-vector control of a saturated
 6.7-kW synchronous reluctance motor drive. The saturation is not taken into
-account in the control method (only in the system model).
+account in the control method (only in the system model). Even if the machine 
+has no magnets, the PM-flux disturbance estimation is enabled [#Tuo2018]_. In 
+this case, this PM-flux estimate lumps the effects of inductance errors. 
+Naturally, the PM-flux estimation can be used in PM machine drives as well. 
 
 """
 
@@ -12,6 +15,7 @@ account in the control method (only in the system model).
 # Imports.
 
 import numpy as np
+import matplotlib.pyplot as plt
 from motulator import model, control
 from motulator import BaseValues, Sequence, plot
 
@@ -53,17 +57,24 @@ converter = model.Inverter(u_dc=540)
 mdl = model.sm.Drive(machine, mechanics, converter)
 
 # %%
-# Configure the control system.
+# Configure the control system. The saturation is not taken into account.
+# Furthermore, the inductance estimates L_d and L_q are intentionally set to
+# lower values in order to demonstrate the PM-flux disturbance estimation.
 
 par = control.sm.ModelPars(
-    n_p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0, J=.015)
+    n_p=2, R_s=.54, L_d=.7*37e-3, L_q=.8*6.2e-3, psi_f=0, J=.015)
 # Disable MTPA since the control system does not consider the saturation
 ref = control.sm.FluxTorqueReferencePars(
     par, i_s_max=2*base.i, k_u=.9, psi_s_min=base.psi, psi_s_max=base.psi)
 ctrl = control.sm.FluxVectorCtrl(par, ref, sensorless=True)
 # Since the saturation is not considered in the control system, the speed
-# estimation bandwidth is set to a lower value
-ctrl.observer = control.sm.Observer(par, alpha_o=2*np.pi*50)
+# estimation bandwidth is set to a lower value. Furthermore, the PM-flux
+# disturbance estimation is enabled at speeds above 2*pi*20 rad/s (electrical).
+ctrl.observer = control.sm.Observer(
+    par,
+    alpha_o=2*np.pi*40,
+    k_f=lambda w_m: max(.05*(np.abs(w_m) - 2*np.pi*20), 0),
+    sensorless=True)
 
 # %%
 # Set the speed reference and the external load torque.
@@ -84,6 +95,32 @@ sim = model.Simulation(mdl, ctrl)
 sim.simulate(t_stop=4)
 
 # %%
-# Plot results in per-unit values.
+# Plot results in per-unit values. The transient after t = 0.5 s is due to the
+# errors in the inductances. The PM-flux estimate compensates for these errors.
 
 plot(sim, base)
+
+# %%
+# Plot the flux linkages and the PM-flux disturbance estimate. Due to the
+# inductance errors and the magnetic saturation, it is nonzero even if the
+# machine has no magnets.
+
+mdl = sim.mdl.data  # Continuous-time data
+ctrl = sim.ctrl.data  # Discrete-time data
+plt.figure()
+plt.plot(mdl.t, np.abs(mdl.psi_s)/base.psi, label=r"$\psi_\mathrm{s}$")
+plt.plot(ctrl.t, np.abs(ctrl.psi_s)/base.psi, label=r"$\hat{\psi}_\mathrm{s}$")
+plt.plot(ctrl.t, ctrl.psi_f/base.psi, label=r"$\hat{\psi}_\mathrm{f}$")
+plt.plot(ctrl.t, ctrl.psi_s_ref/base.psi, "--", label=r"$\psi_\mathrm{s,ref}$")
+plt.xlim(0, 4)
+plt.xlabel("Time (s)")
+plt.ylabel("Flux linkage (p.u.)")
+plt.legend()
+plt.show()
+
+# %%
+# .. rubric:: References
+#
+# .. [#Tuo2018] Tuovinen, Awan, Kukkola, Saarakkala, Hinkkanen, "Permanent-
+#    magnet flux adaptation for sensorless synchronous motor drives," Proc.
+#    IEEE SLED, 2018, https://doi.org/10.1109/SLED.2018.8485899

--- a/motulator/control/sm/_flux_vector.py
+++ b/motulator/control/sm/_flux_vector.py
@@ -119,7 +119,7 @@ class FluxVectorCtrl(Ctrl):
         i_s_abc = mdl.machine.meas_currents()  # Phase currents
         u_dc = mdl.converter.meas_dc_voltage()  # DC-bus voltage
         u_s = self.pwm.realized_voltage  # Realized voltage from PWM
-        #
+
         if self.sensorless:
             # Get the rotor speed and position estimates
             w_m, theta_m = self.observer.w_m, self.observer.theta_m
@@ -162,6 +162,7 @@ class FluxVectorCtrl(Ctrl):
             i_s=i_s,
             psi_s=psi_s,
             psi_s_ref=psi_s_ref,
+            psi_f=self.observer.psi_f,
             t=self.clock.t,
             tau_M_ref_lim=tau_M_ref_lim,
             theta_m=theta_m,
@@ -215,7 +216,7 @@ class FluxTorqueReferencePars:
     i_s_max: float = None
     psi_s_min: float = None
     psi_s_max: float = np.inf
-    k_u: float = 0.95
+    k_u: float = .95
 
     def __post_init__(self, par):
         self.psi_s_min = par.psi_f if self.psi_s_min is None else self.psi_s_min

--- a/motulator/control/sm/_observers.py
+++ b/motulator/control/sm/_observers.py
@@ -1,11 +1,11 @@
-"""
-State observers for synchronous machines.
-"""
+"""State observers for synchronous machines."""
+
 import numpy as np
 from motulator._helpers import wrap
 
 
 # %%
+# pylint: disable=too-many-instance-attributes
 class Observer:
     """
     Observer for synchronous machines in estimated rotor coordinates.


### PR DESCRIPTION
This pull request adds the PM-flux disturbance estimation to a sensorless observer for synchronous machines. This estimation method is demonstrated in one example. 