### PR TITLE
Add torque-control mode, refactoring in the simulation and mechanics modules

### DIFF
--- a/docs/source/model/figs/mech_block.svg
+++ b/docs/source/model/figs/mech_block.svg
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="480"
    height="85.000053"
    id="svg6781"
    version="1.1"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="mech_block.svg"
-   viewBox="0 0 480.00001 85.000056">
+   viewBox="0 0 480.00001 85.000056"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -22,14 +22,14 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8"
-     inkscape:cx="253.29835"
-     inkscape:cy="101.15029"
+     inkscape:zoom="5.6"
+     inkscape:cx="253.75"
+     inkscape:cy="72.232143"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1136"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -41,7 +41,10 @@
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
-     fit-margin-bottom="0">
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="0.5"
        spacingx="0.5"
@@ -504,6 +507,20 @@
            id="path2799" />
       </symbol>
     </g>
+    <clipPath
+       id="clipPath103">
+      <path
+         clip-rule="nonzero"
+         d="M 4,1 H 9 V 5.785156 H 4 Z m 0,0"
+         id="path9146" />
+    </clipPath>
+    <clipPath
+       id="clipPath7282">
+      <path
+         clip-rule="nonzero"
+         d="m 10,4 h 1 v 3.140625 h -1 z m 0,0"
+         id="path4249" />
+    </clipPath>
   </defs>
   <metadata
      id="metadata6786">
@@ -521,10 +538,10 @@
      id="layer1"
      inkscape:groupmode="layer"
      inkscape:label="Layer 1"
-     transform="translate(-75,-804.99994)">
+     transform="translate(-75, -805)">
     <g
        id="g1711"
-       transform="matrix(1,0,0,-1,7.499996,1749.9999)">
+       transform="matrix(1,0,0,-1,7.499994,1747.4999)">
       <path
          style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend-9-7)"
          d="m 287.5,874.99997 -30,-4e-5"
@@ -553,7 +570,7 @@
     </g>
     <g
        id="g1685"
-       transform="matrix(1,0,0,-1,7.500006,1749.9998)">
+       transform="matrix(1,0,0,-1,7.500004,1747.4998)">
       <path
          style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend-9-7)"
          d="m 204.99999,874.99982 h 37.5"
@@ -584,11 +601,11 @@
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path3369"
-       d="m 305,829.99997 h 20"
+       d="m 305,827.49996 h 20"
        style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend-9-7)" />
     <path
        style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend-9-7)"
-       d="M 257.5,829.99993 285,830"
+       d="m 257.5,827.49992 27.5,7e-5"
        id="path4636"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -596,19 +613,19 @@
        sodipodi:nodetypes="ccc"
        inkscape:connector-curvature="0"
        id="path4754"
-       d="m 355,829.99997 v 44.99996 l -20,0"
+       d="m 355,827.49996 v 44.99996 h -20"
        style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#DotM);marker-end:url(#Arrow2Mend-9)" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path4650"
-       d="m 345,829.99994 h 30"
+       d="m 345,827.49993 h 30"
        style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend-9-7)" />
     <rect
        style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.333;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect4620"
        width="20"
-       y="810"
+       y="807.5"
        x="325"
        height="40"
        inkscape:export-filename="C:\Documents and Settings\mhinkkan\Desktop\testi3.png"
@@ -616,13 +633,13 @@
        inkscape:export-ydpi="300" />
     <path
        style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend-9-7)"
-       d="M 212.5,829.99991 H 250"
+       d="M 212.5,827.4999 H 250"
        id="path4648"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <g
        id="g4642"
-       transform="matrix(0,0.7272727,-0.7272727,0,52.112114,807.45446)"
+       transform="matrix(0,0.7272727,-0.7272727,0,52.112112,804.95445)"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.5px;line-height:125%;font-family:'Nimbus Roman No9 L';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline">
       <path
          transform="translate(10.5,17.500004)"
@@ -642,12 +659,12 @@
     <path
        id="path4644"
        sodipodi:nodetypes="cc"
-       d="m 245.22724,845.49999 h 7.27273"
+       d="m 245.22724,842.99998 h 7.27273"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.5px;line-height:125%;font-family:'Nimbus Roman No9 L';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:none;stroke:#000000;stroke-width:0.727273px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <g
        inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,215.48584,727.57322)"
+       transform="matrix(1.25,0,0,1.25,215.48584,725.07321)"
        id="g2446"
        style="stroke-width:0.8">
       <g
@@ -686,7 +703,7 @@
     </g>
     <g
        inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,97.101554,721.0002)"
+       transform="matrix(1.25,0,0,1.25,97.101552,718.50019)"
        id="g1735"
        style="stroke-width:0.8">
       <g
@@ -720,41 +737,7 @@
     </g>
     <g
        inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,145.01803,750.70049)"
-       id="g2920"
-       style="stroke-width:0.8">
-      <g
-         id="g7886"
-         style="stroke-width:0.8">
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g7945">
-          <use
-             xlink:href="#symbol529"
-             x="91.925003"
-             y="81.962997"
-             id="use9597"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g8028">
-          <use
-             xlink:href="#symbol9847"
-             x="96.279999"
-             y="83.457001"
-             id="use7099"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-      </g>
-    </g>
-    <g
-       inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,234.60156,721.00029)"
+       transform="matrix(1.25,0,0,1.25,234.60156,718.50028)"
        id="g3347"
        style="stroke-width:0.8">
       <g
@@ -790,7 +773,7 @@
        style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.333;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect3367"
        width="20"
-       y="810"
+       y="807.5"
        x="285"
        height="40"
        inkscape:export-filename="C:\Documents and Settings\mhinkkan\Desktop\testi3.png"
@@ -798,7 +781,7 @@
        inkscape:export-ydpi="300" />
     <g
        inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,174.5459,727.50492)"
+       transform="matrix(1.25,0,0,1.25,174.5459,725.00491)"
        id="g2507"
        style="stroke-width:0.8">
       <g
@@ -839,7 +822,7 @@
        ry="7.4999976"
        rx="7.5000033"
        cy="-257.5"
-       cx="874.99988"
+       cx="872.49988"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:'Nimbus Roman No9 L';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="ellipse3371"
        transform="rotate(90)" />
@@ -847,129 +830,21 @@
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path3769"
-       d="M 257.5,867.49992 V 837.49988"
+       d="M 257.5,864.99991 V 834.99987"
        style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Mend-9)" />
     <ellipse
        ry="7.4999976"
        rx="7.5000033"
        cy="-257.5"
-       cx="829.99994"
+       cx="827.49994"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:'Nimbus Roman No9 L';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="ellipse4646"
        transform="rotate(90)" />
-    <g
-       inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,97.101552,766.50113)"
-       id="g1352"
-       style="stroke-width:0.8">
-      <g
-         id="g4895"
-         style="stroke-width:0.8">
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g6026">
-          <use
-             xlink:href="#symbol449"
-             x="91.925003"
-             y="81.962997"
-             id="use1506"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g9871">
-          <use
-             xlink:href="#symbol1030"
-             x="96.279999"
-             y="83.457001"
-             id="use6948"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g5814">
-          <use
-             xlink:href="#symbol7057"
-             x="101.206"
-             y="83.457001"
-             id="use4053"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-          <use
-             xlink:href="#symbol1585"
-             x="103.57221"
-             y="83.457001"
-             id="use1583"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-      </g>
-    </g>
-    <g
-       inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,155.97758,766.50114)"
-       id="g1579"
-       style="stroke-width:0.8">
-      <g
-         id="g4555"
-         style="stroke-width:0.8">
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g26">
-          <use
-             xlink:href="#symbol5741"
-             x="91.925003"
-             y="81.962997"
-             id="use8528"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g8303">
-          <use
-             xlink:href="#symbol6347"
-             x="96.279999"
-             y="83.457001"
-             id="use7216"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g3078">
-          <use
-             xlink:href="#symbol185"
-             x="101.206"
-             y="83.457001"
-             id="use3971"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-          <use
-             xlink:href="#symbol6041"
-             x="103.57221"
-             y="83.457001"
-             id="use2389"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-      </g>
-    </g>
     <rect
        style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.333;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect1652"
        width="40.000004"
-       y="859.99994"
+       y="857.49994"
        x="295"
        height="30.00001"
        inkscape:export-filename="C:\Documents and Settings\mhinkkan\Desktop\testi3.png"
@@ -977,7 +852,7 @@
        inkscape:export-ydpi="300" />
     <g
        id="g1669"
-       transform="matrix(0.66666667,0,0,0.66666697,33.333328,258.33301)"
+       transform="matrix(0.66666667,0,0,0.66666697,33.333326,255.833)"
        style="stroke-width:1.5">
       <rect
          inkscape:export-ydpi="300"
@@ -1013,6 +888,116 @@
          id="path1662"
          d="m 422.14285,912.49992 0.17858,25"
          style="display:inline;fill:none;stroke:#000000;stroke-width:0.75;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:none;marker-end:none" />
+    </g>
+    <g
+       inkscape:label=""
+       transform="translate(211.68752,860.96739)"
+       id="g845">
+      <g
+         fill="#000000"
+         fill-opacity="1"
+         id="g17"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           id="use15"
+           transform="translate(0,4.29)">
+          <path
+             d="m 2.9375,-3.71875 h 1.671875 c 0.125,0 0.484375,0 0.484375,-0.34375 0,-0.234375 -0.203125,-0.234375 -0.40625,-0.234375 H 1.90625 c -0.203125,0 -0.59375,0 -1.03125,0.46875 -0.328125,0.359375 -0.609375,0.84375 -0.609375,0.890625 0,0.015625 0,0.109375 0.125,0.109375 0.078125,0 0.09375,-0.046875 0.15625,-0.125 C 1.03125,-3.71875 1.609375,-3.71875 1.8125,-3.71875 h 0.828125 l -0.96875,3.203125 C 1.625,-0.40625 1.5625,-0.1875 1.5625,-0.15625 c 0,0.109375 0.078125,0.28125 0.296875,0.28125 0.328125,0 0.375,-0.28125 0.40625,-0.4375 z m 0,0"
+             id="path29" />
+        </g>
+      </g>
+      <g
+         clip-path="url(#clipPath103)"
+         id="g23"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           fill="#000000"
+           fill-opacity="1"
+           id="g21">
+          <g
+             id="use19"
+             transform="translate(4.355,5.7839999)">
+            <path
+               d="M 4.53125,-1.828125 H 4.296875 C 4.21875,-1.15625 4.125,-0.25 2.796875,-0.25 h -0.6875 c -0.328125,0 -0.34375,-0.0625 -0.34375,-0.265625 V -4.1875 c 0,-0.234375 0,-0.328125 0.65625,-0.328125 h 0.25 v -0.25 C 2.515625,-4.75 1.625,-4.734375 1.453125,-4.734375 c -0.265625,0 -1.0625,-0.03125 -1.0625,-0.03125 v 0.25 H 0.5625 c 0.53125,0 0.546875,0.078125 0.546875,0.328125 v 3.625 c 0,0.234375 -0.015625,0.3125 -0.546875,0.3125 H 0.390625 V 0 h 3.9375 z m 0,0"
+               id="path33" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <g
+       inkscape:label=""
+       transform="translate(259.78126,849.55207)"
+       id="g1428">
+      <g
+         fill="#000000"
+         fill-opacity="1"
+         id="g1412"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           id="use24"
+           transform="translate(0,4.29)">
+          <path
+             d="m 2.9375,-3.71875 h 1.671875 c 0.125,0 0.484375,0 0.484375,-0.34375 0,-0.234375 -0.203125,-0.234375 -0.40625,-0.234375 H 1.90625 c -0.203125,0 -0.59375,0 -1.03125,0.46875 -0.328125,0.359375 -0.609375,0.84375 -0.609375,0.890625 0,0.015625 0,0.109375 0.125,0.109375 0.078125,0 0.09375,-0.046875 0.15625,-0.125 C 1.03125,-3.71875 1.609375,-3.71875 1.8125,-3.71875 h 0.828125 l -0.96875,3.203125 C 1.625,-0.40625 1.5625,-0.1875 1.5625,-0.15625 c 0,0.109375 0.078125,0.28125 0.296875,0.28125 0.328125,0 0.375,-0.28125 0.40625,-0.4375 z m 0,0"
+             id="path50" />
+        </g>
+      </g>
+      <g
+         fill="#000000"
+         fill-opacity="1"
+         id="g30"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           id="use28"
+           transform="translate(4.355,5.7839999)">
+          <path
+             d="M 4.53125,-1.828125 H 4.296875 C 4.21875,-1.15625 4.125,-0.25 2.796875,-0.25 h -0.6875 c -0.328125,0 -0.34375,-0.0625 -0.34375,-0.265625 V -4.1875 c 0,-0.234375 0,-0.328125 0.65625,-0.328125 h 0.25 v -0.25 C 2.515625,-4.75 1.625,-4.734375 1.453125,-4.734375 c -0.265625,0 -1.0625,-0.03125 -1.0625,-0.03125 v 0.25 H 0.5625 c 0.53125,0 0.546875,0.078125 0.546875,0.328125 v 3.625 c 0,0.234375 -0.015625,0.3125 -0.546875,0.3125 H 0.390625 V 0 h 3.9375 z m 0,0"
+             id="path54" />
+        </g>
+      </g>
+      <g
+         clip-path="url(#clipPath7282)"
+         id="g36"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           fill="#000000"
+           fill-opacity="1"
+           id="g34">
+          <g
+             id="use32"
+             transform="translate(9.2810001,5.7839999)">
+            <path
+               d="m 1.46875,-0.109375 c 0,0.375 -0.0625,0.828125 -0.546875,1.265625 C 0.90625,1.1875 0.875,1.21875 0.875,1.25 c 0,0.046875 0.0625,0.09375 0.09375,0.09375 0.109375,0 0.703125,-0.5625 0.703125,-1.390625 0,-0.421875 -0.171875,-0.75 -0.5,-0.75 -0.21875,0 -0.390625,0.171875 -0.390625,0.390625 C 0.78125,-0.1875 0.9375,0 1.1875,0 1.359375,0 1.46875,-0.109375 1.46875,-0.109375 Z m 0,0"
+               id="path58" />
+          </g>
+        </g>
+      </g>
+      <g
+         fill="#000000"
+         fill-opacity="1"
+         id="g44"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           id="use38"
+           transform="translate(11.647,5.7839999)">
+          <path
+             d="M 1.40625,-2.75 H 2.484375 V -3 H 1.40625 v -1.28125 h -0.25 c 0,0.625 -0.28125,1.3125 -0.953125,1.328125 V -2.75 H 0.84375 v 1.875 c 0,0.78125 0.59375,0.9375 0.984375,0.9375 0.46875,0 0.78125,-0.390625 0.78125,-0.9375 V -1.265625 H 2.375 v 0.375 c 0,0.484375 -0.21875,0.734375 -0.5,0.734375 -0.46875,0 -0.46875,-0.578125 -0.46875,-0.703125 z m 0,0"
+             id="path62" />
+        </g>
+        <g
+           id="use40"
+           transform="translate(14.760104,5.7839999)">
+          <path
+             d="m 3.6875,-1.484375 c 0,-0.875 -0.75,-1.625 -1.703125,-1.625 -0.96875,0 -1.71875,0.75 -1.71875,1.625 0,0.859375 0.765625,1.546875 1.71875,1.546875 0.9375,0 1.703125,-0.6875 1.703125,-1.546875 z M 1.984375,-0.15625 c -0.265625,0 -0.640625,-0.078125 -0.875,-0.421875 -0.1875,-0.28125 -0.203125,-0.640625 -0.203125,-0.96875 0,-0.296875 0,-0.71875 0.25,-1.015625 0.171875,-0.203125 0.46875,-0.34375 0.828125,-0.34375 0.40625,0 0.703125,0.1875 0.859375,0.40625 0.1875,0.265625 0.203125,0.625 0.203125,0.953125 0,0.328125 -0.015625,0.703125 -0.21875,0.984375 -0.1875,0.265625 -0.5,0.40625 -0.84375,0.40625 z m 0,0"
+             id="path66" />
+        </g>
+        <g
+           id="use42"
+           transform="translate(18.731684,5.7839999)">
+          <path
+             d="M 1.40625,-2.75 H 2.484375 V -3 H 1.40625 v -1.28125 h -0.25 c 0,0.625 -0.28125,1.3125 -0.953125,1.328125 V -2.75 H 0.84375 v 1.875 c 0,0.78125 0.59375,0.9375 0.984375,0.9375 0.46875,0 0.78125,-0.390625 0.78125,-0.9375 V -1.265625 H 2.375 v 0.375 c 0,0.484375 -0.21875,0.734375 -0.5,0.734375 -0.46875,0 -0.46875,-0.578125 -0.46875,-0.703125 z m 0,0"
+             id="path70" />
+        </g>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/source/model/figs/two_mass_block.svg
+++ b/docs/source/model/figs/two_mass_block.svg
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="480"
    height="215.00002"
    id="svg6781"
    version="1.1"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="two_mass_block.svg"
-   viewBox="0 0 480.00001 215.00002">
+   viewBox="0 0 480.00001 215.00002"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -22,9 +22,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.979899"
-     inkscape:cx="218.95972"
-     inkscape:cy="139.3748"
+     inkscape:zoom="2.8"
+     inkscape:cx="219.46428"
+     inkscape:cy="139.28571"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -41,7 +41,10 @@
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
-     fit-margin-bottom="0">
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="0.5"
        spacingx="0.5"
@@ -670,6 +673,13 @@
            id="path3061" />
       </symbol>
     </g>
+    <clipPath
+       id="clipPath7282">
+      <path
+         clip-rule="nonzero"
+         d="m 10,4 h 1 v 3.140625 h -1 z m 0,0"
+         id="path4249" />
+    </clipPath>
   </defs>
   <metadata
      id="metadata6786">
@@ -679,7 +689,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -884,7 +894,7 @@
     </g>
     <g
        inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,117.51803,735.70046)"
+       transform="matrix(1.25,0,0,1.25,69.373824,751.29797)"
        id="g2920"
        style="stroke-width:0.8">
       <g
@@ -948,114 +958,6 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:'Nimbus Roman No9 L';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="ellipse4646"
        transform="rotate(90)" />
-    <g
-       inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,69.601542,751.5011)"
-       id="g1352"
-       style="stroke-width:0.8">
-      <g
-         id="g4895"
-         style="stroke-width:0.8">
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g6026">
-          <use
-             xlink:href="#symbol449"
-             x="91.925003"
-             y="81.962997"
-             id="use1506"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g9871">
-          <use
-             xlink:href="#symbol1030"
-             x="96.279999"
-             y="83.457001"
-             id="use6948"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g5814">
-          <use
-             xlink:href="#symbol7057"
-             x="101.206"
-             y="83.457001"
-             id="use4053"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-          <use
-             xlink:href="#symbol1585"
-             x="103.57221"
-             y="83.457001"
-             id="use1583"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-      </g>
-    </g>
-    <g
-       inkscape:label=""
-       transform="matrix(1.25,0,0,1.25,128.47758,751.50111)"
-       id="g1579"
-       style="stroke-width:0.8">
-      <g
-         id="g4555"
-         style="stroke-width:0.8">
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g26">
-          <use
-             xlink:href="#symbol5741"
-             x="91.925003"
-             y="81.962997"
-             id="use8528"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g8303">
-          <use
-             xlink:href="#symbol6347"
-             x="96.279999"
-             y="83.457001"
-             id="use7216"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-        <g
-           style="fill:#000000;fill-opacity:1;stroke-width:0.8"
-           id="g3078">
-          <use
-             xlink:href="#symbol185"
-             x="101.206"
-             y="83.457001"
-             id="use3971"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-          <use
-             xlink:href="#symbol6041"
-             x="103.57221"
-             y="83.457001"
-             id="use2389"
-             width="100%"
-             height="100%"
-             style="stroke-width:0.8" />
-        </g>
-      </g>
-    </g>
     <rect
        style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.333;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect1652"
@@ -1740,6 +1642,81 @@
          d="m 19.999996,-279.59586 v 10"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.5px;line-height:125%;font-family:'Nimbus Roman No9 L';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          inkscape:connector-curvature="0" />
+    </g>
+    <g
+       inkscape:label=""
+       transform="translate(232.78126,836.05201)"
+       id="g1428">
+      <g
+         fill="#000000"
+         fill-opacity="1"
+         id="g1412"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           id="use24"
+           transform="translate(0,4.29)">
+          <path
+             d="m 2.9375,-3.71875 h 1.671875 c 0.125,0 0.484375,0 0.484375,-0.34375 0,-0.234375 -0.203125,-0.234375 -0.40625,-0.234375 H 1.90625 c -0.203125,0 -0.59375,0 -1.03125,0.46875 -0.328125,0.359375 -0.609375,0.84375 -0.609375,0.890625 0,0.015625 0,0.109375 0.125,0.109375 0.078125,0 0.09375,-0.046875 0.15625,-0.125 C 1.03125,-3.71875 1.609375,-3.71875 1.8125,-3.71875 h 0.828125 l -0.96875,3.203125 C 1.625,-0.40625 1.5625,-0.1875 1.5625,-0.15625 c 0,0.109375 0.078125,0.28125 0.296875,0.28125 0.328125,0 0.375,-0.28125 0.40625,-0.4375 z m 0,0"
+             id="path50" />
+        </g>
+      </g>
+      <g
+         fill="#000000"
+         fill-opacity="1"
+         id="g30"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           id="use28"
+           transform="translate(4.355,5.7839999)">
+          <path
+             d="M 4.53125,-1.828125 H 4.296875 C 4.21875,-1.15625 4.125,-0.25 2.796875,-0.25 h -0.6875 c -0.328125,0 -0.34375,-0.0625 -0.34375,-0.265625 V -4.1875 c 0,-0.234375 0,-0.328125 0.65625,-0.328125 h 0.25 v -0.25 C 2.515625,-4.75 1.625,-4.734375 1.453125,-4.734375 c -0.265625,0 -1.0625,-0.03125 -1.0625,-0.03125 v 0.25 H 0.5625 c 0.53125,0 0.546875,0.078125 0.546875,0.328125 v 3.625 c 0,0.234375 -0.015625,0.3125 -0.546875,0.3125 H 0.390625 V 0 h 3.9375 z m 0,0"
+             id="path54" />
+        </g>
+      </g>
+      <g
+         clip-path="url(#clipPath7282)"
+         id="g36"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           fill="#000000"
+           fill-opacity="1"
+           id="g34">
+          <g
+             id="use32"
+             transform="translate(9.2810001,5.7839999)">
+            <path
+               d="m 1.46875,-0.109375 c 0,0.375 -0.0625,0.828125 -0.546875,1.265625 C 0.90625,1.1875 0.875,1.21875 0.875,1.25 c 0,0.046875 0.0625,0.09375 0.09375,0.09375 0.109375,0 0.703125,-0.5625 0.703125,-1.390625 0,-0.421875 -0.171875,-0.75 -0.5,-0.75 -0.21875,0 -0.390625,0.171875 -0.390625,0.390625 C 0.78125,-0.1875 0.9375,0 1.1875,0 1.359375,0 1.46875,-0.109375 1.46875,-0.109375 Z m 0,0"
+               id="path58" />
+          </g>
+        </g>
+      </g>
+      <g
+         fill="#000000"
+         fill-opacity="1"
+         id="g44"
+         transform="matrix(1.33333,0,0,1.33333,-0.354167,0.00916672)">
+        <g
+           id="use38"
+           transform="translate(11.647,5.7839999)">
+          <path
+             d="M 1.40625,-2.75 H 2.484375 V -3 H 1.40625 v -1.28125 h -0.25 c 0,0.625 -0.28125,1.3125 -0.953125,1.328125 V -2.75 H 0.84375 v 1.875 c 0,0.78125 0.59375,0.9375 0.984375,0.9375 0.46875,0 0.78125,-0.390625 0.78125,-0.9375 V -1.265625 H 2.375 v 0.375 c 0,0.484375 -0.21875,0.734375 -0.5,0.734375 -0.46875,0 -0.46875,-0.578125 -0.46875,-0.703125 z m 0,0"
+             id="path62" />
+        </g>
+        <g
+           id="use40"
+           transform="translate(14.760104,5.7839999)">
+          <path
+             d="m 3.6875,-1.484375 c 0,-0.875 -0.75,-1.625 -1.703125,-1.625 -0.96875,0 -1.71875,0.75 -1.71875,1.625 0,0.859375 0.765625,1.546875 1.71875,1.546875 0.9375,0 1.703125,-0.6875 1.703125,-1.546875 z M 1.984375,-0.15625 c -0.265625,0 -0.640625,-0.078125 -0.875,-0.421875 -0.1875,-0.28125 -0.203125,-0.640625 -0.203125,-0.96875 0,-0.296875 0,-0.71875 0.25,-1.015625 0.171875,-0.203125 0.46875,-0.34375 0.828125,-0.34375 0.40625,0 0.703125,0.1875 0.859375,0.40625 0.1875,0.265625 0.203125,0.625 0.203125,0.953125 0,0.328125 -0.015625,0.703125 -0.21875,0.984375 -0.1875,0.265625 -0.5,0.40625 -0.84375,0.40625 z m 0,0"
+             id="path66" />
+        </g>
+        <g
+           id="use42"
+           transform="translate(18.731684,5.7839999)">
+          <path
+             d="M 1.40625,-2.75 H 2.484375 V -3 H 1.40625 v -1.28125 h -0.25 c 0,0.625 -0.28125,1.3125 -0.953125,1.328125 V -2.75 H 0.84375 v 1.875 c 0,0.78125 0.59375,0.9375 0.984375,0.9375 0.46875,0 0.78125,-0.390625 0.78125,-0.9375 V -1.265625 H 2.375 v 0.375 c 0,0.484375 -0.21875,0.734375 -0.5,0.734375 -0.46875,0 -0.46875,-0.578125 -0.46875,-0.703125 z m 0,0"
+             id="path70" />
+        </g>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/source/model/mechanics.rst
+++ b/docs/source/model/mechanics.rst
@@ -1,48 +1,36 @@
 Mechanics
 =========
 
-Stiff Mechanics
----------------
+Stiff Mechanical System
+-----------------------
 
-The stiff rotational mechanics are governed by
+The dynamics of a stiff rotational mechanical system are governed by
 
 .. math::
-    J\frac{\mathrm{d}\omega_\mathrm{M}}{\mathrm{d} t} &= \tau_\mathrm{M} - \tau_\mathrm{L} \\
+    J\frac{\mathrm{d}\omega_\mathrm{M}}{\mathrm{d} t} &= \tau_\mathrm{M} - B_\mathrm{L}\omega_\mathrm{M} - \tau_\mathrm{L} \\
     \frac{\mathrm{d}\vartheta_\mathrm{M}}{\mathrm{d} t} &= \omega_\mathrm{M}
     :label: mech_stiff
 
-where :math:`\omega_\mathrm{M}` is the mechanical angular speed of the rotor, :math:`\vartheta_\mathrm{M}` is the mechanical angle of the rotor, :math:`\tau_\mathrm{M}` is the electromagnetic torque, and :math:`J` is the total moment of inertia. The total load torque is
+where :math:`\omega_\mathrm{M}` is the mechanical angular speed of the rotor, :math:`\vartheta_\mathrm{M}` is the mechanical angle of the rotor, :math:`\tau_\mathrm{M}` is the electromagnetic torque, :math:`\tau_\mathrm{L}` is the external load torque as a function of time, :math:`B_\mathrm{L}` is the friction coefficient, and :math:`J` is the total moment of inertia. The total load torque is
 
 .. math::
-    \tau_\mathrm{L} = \tau_{\mathrm{L},\omega} + \tau_{\mathrm{L},t}
-    :label: load_torque
+    \tau_\mathrm{L,tot} = B_\mathrm{L}\omega_\mathrm{M} + \tau_{\mathrm{L}}
+    :label: total_load_torque
 
-where :math:`\tau_{\mathrm{L},\omega}` is the speed-dependent load torque and :math:`\tau_{\mathrm{L},t}` is the external load torque as a function of time. One typical speed-dependent load torque component is viscous friction  
-
-.. math::
-    \tau_{\mathrm{L},\omega} = B\omega_\mathrm{M}
-    :label: viscous_friction
-    
-where :math:`B` is the viscous damping coefficient. Viscous friction appears, e.g., due to laminar fluid flow in bearings. Another typical component is quadratic load torque
-
-.. math:: 
-    \tau_{\mathrm{L},\omega} = k\omega_\mathrm{M}^2\mathrm{sign}(\omega_\mathrm{M})
-    :label: quadratic_load
-    
-which appears, e.g., in pumps and fans as well as in vehicles moving at higher speeds due to air resistance. The model of stiff mechanics is provided in the class :class:`motulator.drive.model.Mechanics`. 
+A constant friction coefficient :math:`B_\mathrm{L}` models viscous friction that appears, e.g., due to laminar fluid flow in bearings. The friction coefficient is allowed to depend on the rotor speed, :math:`B_\mathrm{L} = B_\mathrm{L}(\omega_\mathrm{M})`. As an example, the quadratic load torque profile is achieved choosing :math:`B_\mathrm{L} = k|\omega_\mathrm{M}|`, where :math:`k` is a constant. The quadratic load torque appears, e.g., in pumps and fans as well as in vehicles moving at higher speeds due to air resistance. The model of a stiff mechanical system is provided in the class :class:`motulator.drive.model.StiffMechanicalSystem`. 
 
 .. figure:: figs/mech_block.svg
    :width: 100%
    :align: center
-   :alt: Block diagram of the stiff mechanics.
+   :alt: Block diagram of a stiff mechanical system.
    :target: .
 
-   Block diagram of the stiff mechanics.
+   Block diagram of a stiff mechanical system.
 
-Two-Mass System
----------------
+Two-Mass Mechanical System
+--------------------------
 
-The two-mass mechanics are governed by
+A two-mass mechanical system can be modeled as
 
 .. math::
     J_\mathrm{M}\frac{\mathrm{d}\omega_\mathrm{M}}{\mathrm{d} t} &= \tau_\mathrm{M} - \tau_\mathrm{S} \\
@@ -56,12 +44,17 @@ where :math:`\omega_\mathrm{L}` is the angular speed of the load, :math:`\varthe
     \tau_\mathrm{S} = K_\mathrm{S}\vartheta_\mathrm{ML} + C_\mathrm{S}(\omega_\mathrm{M} - \omega_\mathrm{L})
     :label: shaft_torque
 
-where :math:`K_\mathrm{S}` is the torsional stiffness of the shaft, and :math:`C_\mathrm{S}` is the torsional damping of the shaft. The other quantities correspond to those defined for the stiff mechanics. Two-mass mechanics are modeled in the class :class:`motulator.drive.model.TwoMassMechanics`. See also the example in :doc:`/auto_examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw_two_mass`.
+where :math:`K_\mathrm{S}` is the torsional stiffness of the shaft, and :math:`C_\mathrm{S}` is the torsional damping of the shaft. The other quantities correspond to those defined for the stiff mechanical system. A two-mass mechanical system is modeled in the class :class:`motulator.drive.model.TwoMassMechanicalSystem`. See also the example in :doc:`/auto_examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw_two_mass`.
 
 .. figure:: figs/two_mass_block.svg
    :width: 100%
    :align: center
-   :alt: Block diagram of the two-mass mechanical system.
+   :alt: Block diagram of a two-mass mechanical system.
    :target: .
 
-   Block diagram of the two-mass mechanical system.
+   Block diagram of a two-mass mechanical system.
+
+Externally Specified Rotor Speed
+--------------------------------
+
+It is also possible to omit the mechanical dynamics and directly specify the actual rotor speed :math:`\omega_\mathrm{M}` as a function of time, see the class :class:`motulator.drive.model.ExternalRotorSpeed`. This feature is typically needed when torque-control mode is studied, see the example :doc:`/auto_examples/vector/plot_vector_ctrl_im_2kw_tq_mode`.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,7 +14,7 @@ After :doc:`installation`, *motulator* can be used by creating a continuous-time
    converter = model.Inverter(u_dc=540)
    machine = model.InductionMachineInvGamma(
       R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224, n_p=2)
-   mechanics = model.Mechanics(J=.015)
+   mechanics = model.StiffMechanicalSystem(J=.015)
    mdl = model.Drive(converter, machine, mechanics)
    
    # Discrete-time controller
@@ -25,7 +25,7 @@ After :doc:`installation`, *motulator* can be used by creating a continuous-time
 
    # Acceleration at t = 0.2 s and load torque step of 14 Nm at t = 0.75 s 
    ctrl.ref.w_m = lambda t: (t > .2)*(2*np.pi*50)
-   mdl.mechanics.tau_L_t = lambda t: (t > .75)*14
+   mdl.mechanics.tau_L = lambda t: (t > .75)*14
 
    # Create a simulation object, simulate, and plot example figures
    sim = model.Simulation(mdl, ctrl)

--- a/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
+++ b/examples/flux_vector/plot_flux_vector_pmsm_2kw.py
@@ -24,7 +24,7 @@ base = BaseValues.from_nominal(nom, n_p=2)
 mdl_par = SynchronousMachinePars(
     n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -42,7 +42,7 @@ ctrl = control.FluxVectorCtrl(par, cfg, J=.015, T_s=250e-6, sensorless=True)
 ctrl.ref.w_m = lambda t: (t > .2)*2*base.w
 
 # Load torque step
-mdl.mechanics.tau_L_t = lambda t: (t > .8)*nom.tau*.7
+mdl.mechanics.tau_L = lambda t: (t > .8)*nom.tau*.7
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/flux_vector/plot_flux_vector_pmsyrm_5kw.py
+++ b/examples/flux_vector/plot_flux_vector_pmsyrm_5kw.py
@@ -151,7 +151,7 @@ machine = model.SynchronousMachine(mdl_par, i_s=i_s, psi_s0=psi_s0)
 # mdl_par = SynchronousMachinePars(
 #     n_p=2, R_s=.63, L_d=18e-3, L_q=110e-3, psi_f=.47)
 # machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -178,7 +178,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/flux_vector/plot_flux_vector_syrm_7kw.py
+++ b/examples/flux_vector/plot_flux_vector_syrm_7kw.py
@@ -55,7 +55,7 @@ machine = model.SynchronousMachine(mdl_par, i_s=i_s, psi_s0=0)
 # mdl_par = SynchronousMachinePars(
 #     n_p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
 # machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -90,7 +90,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.
@@ -114,7 +114,7 @@ ctrl = sim.ctrl.data  # Discrete-time data
 ctrl.t = ctrl.ref.t  # Discrete time
 plt.figure()
 plt.plot(
-    mdl.data.t,
+    mdl.machine.data.t,
     np.abs(mdl.machine.data.psi_s)/base.psi,
     label=r"$\psi_\mathrm{s}$")
 plt.plot(

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_im_2kw.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_im_2kw.py
@@ -30,7 +30,7 @@ mdl_ig_par = InductionMachineInvGammaPars(
     n_p=2, R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224)
 mdl_par = InductionMachinePars.from_inv_gamma_model_pars(mdl_ig_par)
 machine = model.InductionMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -57,11 +57,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
-
-# Quadratic load torque profile, e.g. pumps and fans (uncomment to enable)
-# k = 1.1*base.tau_nom/(base.w/base.n_p)**2
-# mdl.mechanics.tau_L_w = lambda w_M: np.sign(w_M)*k*w_M**2
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw.py
@@ -26,7 +26,7 @@ base = BaseValues.from_nominal(nom, n_p=3)
 mdl_par = SynchronousMachinePars(
     n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -48,7 +48,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*8
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw_two_mass.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_pmsm_2kw_two_mass.py
@@ -17,7 +17,8 @@ import matplotlib.pyplot as plt
 from motulator.drive import model
 import motulator.drive.control.sm as control
 from motulator.drive.utils import (
-    BaseValues, NominalValues, plot, Sequence, SynchronousMachinePars)
+    BaseValues, NominalValues, plot, Sequence, SynchronousMachinePars,
+    TwoMassMechanicalSystemPars)
 
 # %%
 # Compute base values based on the nominal values (just for figures).
@@ -31,8 +32,8 @@ base = BaseValues.from_nominal(nom, n_p=3)
 mdl_par = SynchronousMachinePars(
     n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.TwoMassMechanics(
-    J_M=.005, J_L=.005, K_S=700, C_S=.01)  # C_S=.13
+mdl_mec_par = TwoMassMechanicalSystemPars(J_M=.005, J_L=.005, K_S=700, C_S=.01)
+mechanics = model.TwoMassMechanicalSystem(mdl_mec_par)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -54,7 +55,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .4, .4, 1])
 values = np.array([0, 0, 1, 1])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.
@@ -70,10 +71,14 @@ plot(sim, base)  # Plot results in per-unit values
 t_span = (0, 1.2)
 _, (ax1, ax2) = plt.subplots(2, 1, figsize=(8, 5))
 ax1.plot(
-    sim.mdl.data.t, sim.mdl.mechanics.data.w_M, label=r"$\omega_\mathrm{M}$")
+    sim.mdl.mechanics.data.t,
+    sim.mdl.mechanics.data.w_M,
+    label=r"$\omega_\mathrm{M}$")
 ax1.plot(
-    sim.mdl.data.t, sim.mdl.mechanics.data.w_L, label=r"$\omega_\mathrm{L}$")
-ax2.plot(sim.mdl.data.t, sim.mdl.mechanics.data.theta_ML*180/np.pi)
+    sim.mdl.mechanics.data.t,
+    sim.mdl.mechanics.data.w_L,
+    label=r"$\omega_\mathrm{L}$")
+ax2.plot(sim.mdl.mechanics.data.t, sim.mdl.mechanics.data.theta_ML*180/np.pi)
 ax1.set_xlim(t_span)
 ax2.set_xlim(t_span)
 ax1.set_xticklabels([])
@@ -91,8 +96,8 @@ plt.show()
 f_span = (5, 500)
 num = 200
 # Parameters
-J_M, J_L = mdl.mechanics.J_M, mdl.mechanics.J_L
-K_S, C_S = mdl.mechanics.K_S, mdl.mechanics.C_S
+J_M, J_L = mdl_mec_par.J_M, mdl_mec_par.J_L
+K_S, C_S = mdl_mec_par.K_S, mdl_mec_par.C_S
 # Frequencies
 w = 2*np.pi*np.logspace(np.log10(f_span[0]), np.log10(f_span[-1]), num=num)
 s = 1j*w

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_pmsyrm_thor.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_pmsyrm_thor.py
@@ -95,7 +95,9 @@ machine = model.SynchronousMachine(mdl_par, i_s=i_s, psi_s0=psi_s0)
 # mdl_par = SynchronousMachinePars(
 #     n_p=2, R_s=.2, L_d=4e-3, L_q=17e-3, psi_f=.134)
 # machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.0042)
+# Quadratic load torque profile (corresponding to pumps and fans)
+k = nom.tau/(base.w/base.n_p)**2
+mechanics = model.StiffMechanicalSystem(J=.0042, B_L=lambda w_M: k*np.abs(w_M))
 converter = model.Inverter(u_dc=310)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -114,14 +116,8 @@ times = np.array([0, .125, .25, .375, .5, .625, .75, .875, 1])*8
 values = np.array([0, 0, 1, 1, 0, -1, -1, 0, 0])*base.w
 ctrl.ref.w_m = Sequence(times, values)
 
-# Quadratic load torque profile (corresponding to pumps and fans)
-k = nom.tau/(base.w/base.n_p)**2
-mdl.mechanics.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
-
-# Uncomment to try the rated load torque step at t = 1 s (set k = 0 above)
-# times = np.array([0, .125, .125, .875, .875, 1])*8
-# values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-# mdl.mechanics.tau_L_t = Sequence(times, values)
+# External load torque set to zero
+mdl.mechanics.tau_L = lambda t: (t > 0)*0
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/obs_vhz/plot_obs_vhz_ctrl_syrm_7kw.py
+++ b/examples/obs_vhz/plot_obs_vhz_ctrl_syrm_7kw.py
@@ -82,7 +82,7 @@ machine = model.SynchronousMachine(mdl_par, i_s=i_s, psi_s0=0)
 # mdl_par = SynchronousMachinePars(
 #     n_p=2, R_s=.54, L_d=37e-3, L_q=6.2e-3, psi_f=0)
 # machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -104,7 +104,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*8
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
+++ b/examples/signal_inj/plot_signal_inj_pmsm_2kw.py
@@ -28,7 +28,7 @@ base = BaseValues.from_nominal(nom, n_p=3)
 mdl_par = SynchronousMachinePars(
     n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -50,7 +50,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.
@@ -70,7 +70,10 @@ ctrl = sim.ctrl.data  # Discrete-time data
 ctrl.t = ctrl.ref.t  # Discrete time
 
 plt.figure()
-plt.plot(mdl.data.t, mdl.machine.data.theta_m, label=r"$\vartheta_\mathrm{m}$")
+plt.plot(
+    mdl.machine.data.t,
+    mdl.machine.data.theta_m,
+    label=r"$\vartheta_\mathrm{m}$")
 plt.plot(
     ctrl.t,
     ctrl.fbk.theta_m,

--- a/examples/signal_inj/plot_signal_inj_syrm_7kw.py
+++ b/examples/signal_inj/plot_signal_inj_syrm_7kw.py
@@ -28,7 +28,7 @@ base = BaseValues.from_nominal(nom, n_p=2)
 mdl_par = SynchronousMachinePars(
     n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -52,7 +52,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object and simulate it.
@@ -71,7 +71,10 @@ mdl = sim.mdl  # Continuous-time data
 ctrl = sim.ctrl.data  # Discrete-time data
 ctrl.t = ctrl.ref.t  # Discrete time
 plt.figure()
-plt.plot(mdl.data.t, mdl.machine.data.theta_m, label=r"$\vartheta_\mathrm{m}$")
+plt.plot(
+    mdl.machine.data.t,
+    mdl.machine.data.theta_m,
+    label=r"$\vartheta_\mathrm{m}$")
 plt.plot(
     ctrl.t,
     ctrl.fbk.theta_m,

--- a/examples/vector/plot_vector_ctrl_im_2kw.py
+++ b/examples/vector/plot_vector_ctrl_im_2kw.py
@@ -22,38 +22,17 @@ nom = NominalValues(U=400, I=5, f=50, P=2.2e3, tau=14.6)
 base = BaseValues.from_nominal(nom, n_p=2)
 
 # %%
-# Configure the system model.
-
-# %%
-# The main-flux saturation is modeled based on [#Qu2012]_. For simplicity, the
-# parameters are hardcoded in the function below, but this model structure can
-# be used also for other induction machines.
+# The main-flux saturation in the system model is modeled based on [#Qu2012]_.
+# The default parameters correspond to the measured data of a 2.2-kW machine.
 
 
-def L_s(psi):
-    """
-    Stator inductance saturation model for a 2.2-kW induction machine.
-
-    Parameters
-    ----------
-    psi : float
-        Magnitude of the stator flux linkage (Vs).
-    
-    Returns
-    -------
-    float
-        Stator inductance (H).
-
-    """
-    # Saturation model parameters for a 2.2-kW induction machine, based on the
-    # measured data
-    L_su, beta, S = .34, .84, 7
-    # Stator inductance
+def L_s(psi, L_su=.34, beta=.84, S=7):
+    """Stator inductance saturation model."""
     return L_su/(1 + (beta*psi)**S)
 
 
 # %%
-# Create the system model.
+# Configure the system model.
 
 # Γ-equivalent machine model with main-flux saturation included
 mdl_par = InductionMachinePars(n_p=2, R_s=3.7, R_r=2.5, L_ell=.023, L_s=L_s)
@@ -62,9 +41,7 @@ mdl_par = InductionMachinePars(n_p=2, R_s=3.7, R_r=2.5, L_ell=.023, L_s=L_s)
 #     n_p=2, R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224)
 # mdl_par = InductionMachinePars.from_inv_gamma_model_pars(par)
 machine = model.InductionMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
-#mechanics = model.TwoMassMechanics(
-#    J_M=.005, J_L=.005, K_S=700, C_S=.01)  # C_S=.13
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 # mdl.pwm = model.CarrierComparison()  # Try to enable the PWM model
@@ -83,7 +60,7 @@ cfg = control.CurrentReferenceCfg(
 ctrl = control.CurrentVectorCtrl(par, cfg, J=.015, T_s=250e-6, sensorless=True)
 # As an example, you may replace the default 2DOF PI speed controller with the
 # regular PI speed controller by uncommenting the following line
-# from motulator.common import PICtrl
+# from motulator.common.control import PICtrl
 # ctrl.speed_ctrl = PICtrl(k_p=1, k_i=1)
 
 # %%
@@ -92,11 +69,11 @@ ctrl = control.CurrentVectorCtrl(par, cfg, J=.015, T_s=250e-6, sensorless=True)
 
 # Simple acceleration and load torque step
 ctrl.ref.w_m = lambda t: (t > .2)*(.5*base.w)
-mdl.mechanics.tau_L_t = lambda t: (t > .75)*nom.tau
+mdl.mechanics.tau_L = lambda t: (t > .75)*nom.tau
 
 # No load, field-weakening (uncomment to try)
 # ctrl.ref.w_m = lambda t: (t > .2)*(2*base.w)
-# mdl.mechanics.tau_L_t = lambda t: 0
+# mdl.mechanics.tau_L = lambda t: 0
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/vector/plot_vector_ctrl_im_2kw_tq_mode.py
+++ b/examples/vector/plot_vector_ctrl_im_2kw_tq_mode.py
@@ -1,0 +1,67 @@
+"""
+2.2-kW induction motor, torque-control mode
+===========================================
+
+This example simulates current-vector control of a 2.2-kW induction motor drive
+in torque-control mode. 
+
+"""
+# %%
+import numpy as np
+
+from motulator.drive import model
+import motulator.drive.control.im as control
+from motulator.drive.utils import (
+    BaseValues, NominalValues, plot, InductionMachinePars,
+    InductionMachineInvGammaPars)
+
+# %%
+# Compute base values based on the nominal values (just for figures).
+
+nom = NominalValues(U=400, I=5, f=50, P=2.2e3, tau=14.6)
+base = BaseValues.from_nominal(nom, n_p=2)
+
+# %%
+# Configure the system model.
+
+# Parametrize the machine model using its inverse-Γ parameters
+par = InductionMachineInvGammaPars(
+    n_p=2, R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224)
+mdl_par = InductionMachinePars.from_inv_gamma_model_pars(par)
+machine = model.InductionMachine(mdl_par)
+# Use external speed w_M_t, defined subsequently below
+mechanics = model.ExternalRotorSpeed()
+converter = model.Inverter(u_dc=540)
+mdl = model.Drive(converter, machine, mechanics)
+
+# %%
+# Configure the control system.
+
+# Machine model parameter estimates
+par = InductionMachineInvGammaPars(
+    n_p=2, R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224)
+# Set nominal values and limits for reference generation
+cfg = control.CurrentReferenceCfg(
+    par, max_i_s=1.5*base.i, nom_u_s=base.u, nom_w_s=base.w)
+# Create the control system
+ctrl = control.CurrentVectorCtrl(par, cfg, T_s=250e-6, sensorless=True)
+
+# %%
+# Set the torque reference and the actual speed.
+
+# Torque reference steps
+ctrl.ref.tau_M = lambda t: (t > .25)*nom.tau - (t > 1.25)*2*nom.tau
+# Actual speed varies sinusoidally
+mdl.mechanics.w_M = lambda t: .5*(base.w/base.n_p)*np.sin(2*np.pi*1*t)
+
+# %%
+# Create the simulation object and simulate it.
+
+sim = model.Simulation(mdl, ctrl)
+sim.simulate(t_stop=2)
+
+# %%
+# Plot results in per-unit values. By omitting the argument `base` you can plot
+# the results in SI units.
+
+plot(sim, base)

--- a/examples/vector/plot_vector_ctrl_pmsm_2kw.py
+++ b/examples/vector/plot_vector_ctrl_pmsm_2kw.py
@@ -27,10 +27,9 @@ base = BaseValues.from_nominal(nom, n_p=3)
 mdl_par = SynchronousMachinePars(
     n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
-# mdl.pwm = model.CarrierComparison()  # Enable the PWM model
 
 # %%
 # Configure the control system.
@@ -46,7 +45,7 @@ ctrl = control.CurrentVectorCtrl(par, cfg, J=.015, T_s=250e-6, sensorless=True)
 ctrl.ref.w_m = lambda t: (t > .2)*2*base.w
 
 # External load torque
-mdl.mechanics.tau_L_t = lambda t: (t > .8)*.7*nom.tau
+mdl.mechanics.tau_L = lambda t: (t > .8)*.7*nom.tau
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/vector/plot_vector_ctrl_pmsm_2kw_diode.py
+++ b/examples/vector/plot_vector_ctrl_pmsm_2kw_diode.py
@@ -25,7 +25,7 @@ base = BaseValues.from_nominal(nom, n_p=3)
 mdl_par = SynchronousMachinePars(
     n_p=3, R_s=3.6, L_d=.036, L_q=.051, psi_f=.545)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.FrequencyConverter(L=2e-3, C=235e-6, U_g=400, f_g=50)
 mdl = model.Drive(converter, machine, mechanics)
 mdl.pwm = model.CarrierComparison()  # Enable the PWM model
@@ -44,7 +44,7 @@ ctrl = control.CurrentVectorCtrl(par, ref, J=.015, T_s=250e-6, sensorless=True)
 ctrl.ref.w_m = lambda t: (t > .2)*base.w
 
 # External load torque
-mdl.mechanics.tau_L_t = lambda t: (t > .6)*nom.tau
+mdl.mechanics.tau_L = lambda t: (t > .6)*nom.tau
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/vector/plot_vector_ctrl_pmsyrm_thor.py
+++ b/examples/vector/plot_vector_ctrl_pmsyrm_thor.py
@@ -28,7 +28,9 @@ base = BaseValues.from_nominal(nom, n_p=2)
 mdl_par = SynchronousMachinePars(
     n_p=2, R_s=.2, L_d=4e-3, L_q=17e-3, psi_f=.134)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.0042)
+# Quadratic load torque profile
+k = .05*nom.tau/(base.w/base.n_p)**2
+mechanics = model.StiffMechanicalSystem(J=.0042, B_L=lambda w_M: k*np.abs(w_M))
 converter = model.Inverter(u_dc=310)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -56,13 +58,10 @@ tq.plot_torque_current(ctrl.current_reference.cfg.max_i_s, base)
 # tq.plot_flux_loci(ctrl.current_reference.cfg.max_i_s, base)
 
 # %%
-# Set the speed reference and the external load torque.
+# Set the speed reference. The external load torque is zero (by default).
 
 # Acceleration and load torque step
 ctrl.ref.w_m = lambda t: (t > .1)*base.w*3
-# Quadratic load torque profile
-k = .05*nom.tau/(base.w/base.n_p)**2
-mdl.mechanics.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
 
 # %%
 # Create the simulation object, simulate, and plot results in per-unit values.

--- a/examples/vector/plot_vector_ctrl_syrm_7kw.py
+++ b/examples/vector/plot_vector_ctrl_syrm_7kw.py
@@ -27,7 +27,7 @@ base = BaseValues.from_nominal(nom, n_p=2)
 mdl_par = SynchronousMachinePars(
     n_p=2, R_s=.54, L_d=41.5e-3, L_q=6.2e-3, psi_f=0)
 machine = model.SynchronousMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+mechanics = model.StiffMechanicalSystem(J=.015)
 converter = model.Inverter(u_dc=540)
 mdl = model.Drive(converter, machine, mechanics)
 
@@ -49,7 +49,7 @@ ctrl.ref.w_m = Sequence(times, values)
 # External load torque
 times = np.array([0, .125, .125, .875, .875, 1])*4
 values = np.array([0, 0, 1, 1, 0, 0])*nom.tau
-mdl.mechanics.tau_L_t = Sequence(times, values)
+mdl.mechanics.tau_L = Sequence(times, values)
 
 # %%
 # Create the simulation object, simulate, and plot results in per-unit values.

--- a/examples/vhz/plot_vhz_ctrl_im_2kw.py
+++ b/examples/vhz/plot_vhz_ctrl_im_2kw.py
@@ -30,8 +30,9 @@ mdl_ig_par = InductionMachineInvGammaPars(
     n_p=2, R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224)
 mdl_par = InductionMachinePars.from_inv_gamma_model_pars(mdl_ig_par)
 machine = model.InductionMachine(mdl_par)
-# Mechanics model
-mechanics = model.Mechanics(J=.015)
+# Mechanical subsystem with the quadratic load torque profile
+k = 1.1*nom.tau/(base.w/base.n_p)**2
+mechanics = model.StiffMechanicalSystem(J=.015, B_L=lambda w_M: k*np.abs(w_M))
 # Frequency converter with a diode bridge
 converter = model.FrequencyConverter(L=2e-3, C=235e-6, U_g=400, f_g=50)
 mdl = model.Drive(converter, machine, mechanics)
@@ -50,12 +51,8 @@ ctrl = control.VHzCtrl(
 
 ctrl.ref.w_m = lambda t: (t > .2)*base.w
 
-# Quadratic load torque profile (corresponding to pumps and fans)
-k = 1.1*nom.tau/(base.w/base.n_p)**2
-mdl.mechanics.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
-
 # Stepwise load torque at t = 1 s, 20% of the rated torque
-mdl.mechanics.tau_L_t = lambda t: (t > 1.)*.2*nom.tau
+mdl.mechanics.tau_L = lambda t: (t > 1.)*.2*nom.tau
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/vhz/plot_vhz_ctrl_im_2kw_lc.py
+++ b/examples/vhz/plot_vhz_ctrl_im_2kw_lc.py
@@ -30,7 +30,9 @@ mdl_ig_par = InductionMachineInvGammaPars(
     n_p=2, R_s=3.7, R_R=2.1, L_sgm=.021, L_M=.224)
 mdl_par = InductionMachinePars.from_inv_gamma_model_pars(mdl_ig_par)
 machine = model.InductionMachine(mdl_par)
-mechanics = model.Mechanics(J=.015)
+# Quadratic load torque profile (corresponding to pumps and fans)
+k = 1.1*nom.tau/(base.w/base.n_p)**2
+mechanics = model.StiffMechanicalSystem(J=.015, B_L=lambda w_M: k*np.abs(w_M))
 converter = model.Inverter(u_dc=540)
 lc_filter = model.LCFilter(L=8e-3, C=9.9e-6, R=.1)
 mdl = model.DriveWithLCFilter(converter, machine, mechanics, lc_filter)
@@ -45,13 +47,9 @@ ctrl = control.VHzCtrl(
     control.VHzCtrlCfg(par, nom_psi_s=base.psi, k_u=0, k_w=0))
 
 # %%
-# Set the speed reference and the external load torque.
+# Set the speed reference. The external load torque is zero (by default).
 
 ctrl.ref.w_m = lambda t: (t > .2)*base.w
-
-# Quadratic load torque profile (corresponding to pumps and fans)
-k = 1.1*nom.tau/(base.w/base.n_p)**2
-mdl.mechanics.tau_L_w = lambda w_M: k*w_M**2*np.sign(w_M)
 
 # %%
 # Create the simulation object and simulate it.
@@ -73,18 +71,26 @@ mdl = sim.mdl  # Continuous-time data
 # Plot the converter and stator voltages (phase a)
 fig1, (ax1, ax2) = plt.subplots(2, 1)
 ax1.plot(
-    mdl.data.t, mdl.converter.data.u_cs.real/base.u, label=r"$u_\mathrm{ca}$")
+    mdl.converter.data.t,
+    mdl.converter.data.u_cs.real/base.u,
+    label=r"$u_\mathrm{ca}$")
 ax1.plot(
-    mdl.data.t, mdl.machine.data.u_ss.real/base.u, label=r"$u_\mathrm{sa}$")
+    mdl.converter.data.t,
+    mdl.machine.data.u_ss.real/base.u,
+    label=r"$u_\mathrm{sa}$")
 ax1.set_xlim(t_span)
 ax1.legend()
 ax1.set_xticklabels([])
 ax1.set_ylabel("Voltage (p.u.)")
 # Plot the converter and stator currents (phase a)
 ax2.plot(
-    mdl.data.t, mdl.converter.data.i_cs.real/base.i, label=r"$i_\mathrm{ca}$")
+    mdl.converter.data.t,
+    mdl.converter.data.i_cs.real/base.i,
+    label=r"$i_\mathrm{ca}$")
 ax2.plot(
-    mdl.data.t, mdl.machine.data.i_ss.real/base.i, label=r"$i_\mathrm{sa}$")
+    mdl.converter.data.t,
+    mdl.machine.data.i_ss.real/base.i,
+    label=r"$i_\mathrm{sa}$")
 ax2.set_xlim(t_span)
 ax2.legend()
 ax2.set_ylabel("Current (p.u.)")

--- a/motulator/drive/control/im/_current_vector.py
+++ b/motulator/drive/control/im/_current_vector.py
@@ -30,7 +30,7 @@ class CurrentVectorCtrl(DriveCtrl):
     cfg : CurrentReferenceCfg
         Current reference generator configuration.
     J : float, optional
-        Moment of inertia (kgm^2). Needed for speed control. 
+        Moment of inertia (kgm^2). Needed only for the speed controller.
     T_s : float, optional
         Sampling time (s). The default is 250e-6.
     sensorless : bool, optional
@@ -53,7 +53,10 @@ class CurrentVectorCtrl(DriveCtrl):
         super().__init__(par, T_s, sensorless)
         self.current_reference = CurrentReference(par, cfg)
         self.current_ctrl = CurrentCtrl(par, 2*np.pi*200)
-        self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        if J is not None:
+            self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        else:
+            self.speed_ctrl = None
         self.observer = Observer(ObserverCfg(par, T_s, sensorless=sensorless))
 
     def output(self, fbk):

--- a/motulator/drive/control/sm/_current_vector.py
+++ b/motulator/drive/control/sm/_current_vector.py
@@ -28,7 +28,7 @@ class CurrentVectorCtrl(DriveCtrl):
     T_s : float, optional
         Sampling period (s). The default is 250e-6.
     J : float, optional
-        Moment of inertia (kg*m^2). Needed for the speed controller.
+        Moment of inertia (kgm^2). Needed only for the speed controller. 
     alpha_c : float, optional
         Current controller bandwidth (rad/s). The default is 2*pi*200.
     alpha_o : float, optional
@@ -61,7 +61,10 @@ class CurrentVectorCtrl(DriveCtrl):
         super().__init__(par, T_s, sensorless)
         self.current_reference = CurrentReference(par, cfg)
         self.current_ctrl = CurrentCtrl(par, alpha_c)
-        self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        if J is not None:
+            self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        else:
+            self.speed_ctrl = None
         if sensorless:
             self.observer = Observer(
                 ObserverCfg(par, sensorless, alpha_o=alpha_o))

--- a/motulator/drive/control/sm/_flux_vector.py
+++ b/motulator/drive/control/sm/_flux_vector.py
@@ -35,7 +35,7 @@ class FluxVectorCtrl(DriveCtrl):
     alpha_o : float, optional
         Observer bandwidth (rad/s). The default is 2*pi*100.
     J : float, optional
-        Moment of inertia (kg*m^2). Needed for the speed controller. 
+        Moment of inertia (kg*m^2). Needed only for the speed controller. 
     T_s : float
         Sampling period (s). The default is 250e-6.
     sensorless : bool, optional
@@ -67,7 +67,10 @@ class FluxVectorCtrl(DriveCtrl):
         super().__init__(par, T_s, sensorless)
         # Subsystems
         self.flux_torque_reference = FluxTorqueReference(cfg)
-        self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        if J is not None:
+            self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        else:
+            self.speed_ctrl = None
         self.observer = Observer(
             ObserverCfg(par, alpha_o=alpha_o, sensorless=sensorless))
         # Bandwidths

--- a/motulator/drive/control/sm/_signal_inj.py
+++ b/motulator/drive/control/sm/_signal_inj.py
@@ -37,7 +37,7 @@ class SignalInjectionCtrl(DriveCtrl):
     cfg : CurrentReferenceCfg
         Reference generation configuration.
     J : float, optional
-        Moment of inertia (kg*m^2). Needed for the speed controller.
+        Moment of inertia (kg*m^2). Needed only for the speed controller.
     T_s : float
         Sampling period (s).
 
@@ -49,7 +49,10 @@ class SignalInjectionCtrl(DriveCtrl):
         self.current_ctrl = CurrentCtrl(par, 2*np.pi*200)
         self.pll = PhaseLockedLoop(w_o=2*np.pi*40)
         self.signal_inj = SignalInjection(par, U_inj=250)
-        self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        if J is not None:
+            self.speed_ctrl = SpeedCtrl(J, 2*np.pi*4)
+        else:
+            self.speed_ctrl = None
         self.observer = None
 
     def get_feedback_signals(self, mdl):

--- a/motulator/drive/model/__init__.py
+++ b/motulator/drive/model/__init__.py
@@ -4,7 +4,8 @@ from motulator.common.model._simulation import (
 from motulator.drive.model._drive import Drive, DriveWithLCFilter
 from motulator.common.model._converter import FrequencyConverter, Inverter
 from motulator.drive.model._machine import InductionMachine, SynchronousMachine
-from motulator.drive.model._mechanics import Mechanics, TwoMassMechanics
+from motulator.drive.model._mechanics import (
+    ExternalRotorSpeed, StiffMechanicalSystem, TwoMassMechanicalSystem)
 from motulator.drive.model._lc_filter import LCFilter
 
 __all__ = [
@@ -17,7 +18,8 @@ __all__ = [
     "Inverter",
     "InductionMachine",
     "SynchronousMachine",
-    "Mechanics",
-    "TwoMassMechanics",
+    "ExternalRotorSpeed",
+    "StiffMechanicalSystem",
+    "TwoMassMechanicalSystem",
     "LCFilter",
 ]

--- a/motulator/drive/model/_drive.py
+++ b/motulator/drive/model/_drive.py
@@ -21,8 +21,9 @@ class Drive(Model):
         Converter model.
     machine : InductionMachine | SynchronousMachine
         Machine model.
-    mechanics : Mechanics | TwoMassMechanics
-        Mechanics model.
+    mechanics : ExternalRotorSpeed | StiffMechanicalSystem |\
+                TwoMassMechanicalSystem                
+        Mechanical subsystem model.
 
     """
 
@@ -37,8 +38,8 @@ class Drive(Model):
         """Interconnect the subsystems."""
         self.converter.inp.i_cs = self.machine.out.i_ss
         self.machine.inp.u_ss = self.converter.out.u_cs
-        self.machine.inp.w_M = self.mechanics.out.w_M
         self.mechanics.inp.tau_M = self.machine.out.tau_M
+        self.machine.inp.w_M = self.mechanics.out.w_M
 
     def post_process(self):
         """Post-process the solution."""
@@ -64,8 +65,9 @@ class DriveWithLCFilter(Model):
         Converter model.
     machine : InductionMachine | SynchronousMachine
         Machine model.
-    mechanics : Mechanics | TwoMassMechanics
-        Mechanics model.
+    mechanics : ExternalRotorSpeed | StiffMechanicalSystem |\
+                TwoMassMechanicalSystem                
+        Mechanical subsystem model.
     lc_filter : LCFilter
         LC-filter model.
 

--- a/motulator/drive/model/_mechanics.py
+++ b/motulator/drive/model/_mechanics.py
@@ -2,55 +2,60 @@
 
 from types import SimpleNamespace
 
+import numpy as np
+
 from motulator.common.model import Subsystem
-from motulator.common.utils import wrap
 
 
 # %%
-class Mechanics(Subsystem):
+class StiffMechanicalSystem(Subsystem):
     """
-    Mechanics subsystem.
-
-    This models an equation of motion for stiff mechanics.
+    Stiff mechanical system.
 
     Parameters
     ----------
     J : float
         Total moment of inertia (kgm²).
-    tau_L_w : callable
-        Load torque (Nm) as a function of speed, `tau_L_w(w_M)`. For example,
-        ``tau_L_w = b*w_M``, where `b` is the viscous friction coefficient. The
-        default is zero, ``lambda w_M: 0*w_M``.
-    tau_L_t : callable
-        Load torque (Nm) as a function of time, `tau_L_t(t)`. The default is 
-        zero, ``lambda t: 0*t``.
+    B_L : float | callable
+        Friction coefficient (Nm/(rad/s)) that can be constant, corresponding 
+        to viscous friction, or an arbitrary function of the rotor speed. For 
+        example, choosing ``B_L = lambda w_M: k*abs(w_M)`` gives the quadratic 
+        load torque ``k*w_M**2``. The default is ``B_L = 0``.
+    tau_L : callable
+        External load torque (Nm) as a function of time, `tau_L_t(t)`. The 
+        default is zero, ``lambda t: 0*t``.
 
     """
 
-    def __init__(self, J, tau_L_w=lambda w_M: 0*w_M, tau_L_t=lambda t: 0*t):
+    def __init__(self, J, B_L=0, tau_L=lambda t: 0*t):
         super().__init__()
-        self.J = J
-        self.tau_L_t, self.tau_L_w = tau_L_t, tau_L_w
-        self.state = SimpleNamespace(w_M=0, theta_M=0)
-        self.sol_states = SimpleNamespace(w_M=[], theta_M=[])
+        self.par = SimpleNamespace(J=J, B_L=B_L)
+        self.tau_L = tau_L
+        # Complex exponent is used to represent the rotor angle to provide
+        # continuity in the angle representation and to avoid wrapping issues.
+        self.state = SimpleNamespace(w_M=0, exp_j_theta_M=complex(1))
+        self.sol_states = SimpleNamespace(w_M=[], exp_j_theta_M=[])
+
+    @property
+    def B_L(self):
+        """Friction coefficient (Nm/(rad/s))."""
+        if callable(self.par.B_L):
+            return self.par.B_L(np.abs(self.state.w_M))
+        return self.par.B_L
 
     def set_outputs(self, t):
         """Set output variables."""
         state, out = self.state, self.out
-        out.w_M, out.theta_M = state.w_M, state.theta_M
-        # Total load torque
-        out.tau_L = self.tau_L_w(state.w_M) + self.tau_L_t(t)
+        out.w_M = state.w_M
+        out.tau_L_tot = self.B_L*out.w_M + self.tau_L(t)
 
     def rhs(self):
         """Compute state derivatives."""
         state, inp, out = self.state, self.inp, self.out
-        d_w_M = (inp.tau_M - out.tau_L)/self.J
-        d_theta_M = state.w_M
-        # Wrap the angle, take the real parts
-        state.theta_M = wrap(state.theta_M.real)
-        state.w_M = state.w_M.real
+        d_w_M = (inp.tau_M - out.tau_L_tot)/self.par.J
+        d_exp_j_theta_M = 1j*state.w_M*state.exp_j_theta_M
 
-        return [d_w_M, d_theta_M]
+        return [d_w_M, d_exp_j_theta_M]
 
     def meas_speed(self):
         """
@@ -62,7 +67,6 @@ class Mechanics(Subsystem):
             Rotor angular speed (mechanical rad/s).
 
         """
-        # The quantization noise of an incremental encoder could be modeled.
         return self.state.w_M.real
 
     def meas_position(self):
@@ -75,81 +79,69 @@ class Mechanics(Subsystem):
             Rotor angle (mechanical rad).
 
         """
-        return self.state.theta_M.real
+        return np.angle(self.state.exp_j_theta_M)
 
     def post_process_states(self):
         """Post-process data."""
-        data = self.data
-        data.w_M = data.w_M.real
-        data.theta_M = wrap(data.theta_M.real)
+        self.data.w_M = self.data.w_M.real
+        self.data.theta_M = np.angle(self.data.exp_j_theta_M)
 
     def post_process_with_inputs(self):
         """Post-process data with inputs."""
         data = self.data
-        data.tau_L = (self.tau_L_t(data.t) + self.tau_L_w(data.w_M))
+        B_L = self.par.B_L(np.abs(data.w_M)) if callable(
+            self.par.B_L) else self.par.B_L
+        data.tau_L_tot = self.tau_L(data.t) + B_L*data.w_M
 
 
 # %%
-class TwoMassMechanics(Mechanics):
+class TwoMassMechanicalSystem(StiffMechanicalSystem):
     """
-    Two-mass mechanics subsystem.
-
-    This models an equation of motion for two-mass mechanics.
+    Two-mass mechanical subsystem.
 
     Parameters
     ----------
-    J_M : float
-        Motor moment of inertia (kgm²).
-    J_L : float
-        Load moment of inertia (kgm²).
-    K_S : float
-        Shaft torsional stiffness (Nm).
-    C_S : float
-        Shaft torsional damping (Nms).
-    tau_L_w : callable
-        Load torque (Nm) as a function of the load speed, `tau_L_w(w_L)`, e.g., 
-        ``tau_L_w = B*w_L``, where `B` is the viscous friction coefficient. The
-        default is zero, ``lambda w_L: 0*w_L``.
-    tau_L_t : callable
-        Load torque (Nm) as a function of time, `tau_L_t(t)`. The default is
+    par : TwoMassMechanicalSystemPars
+        Two-mass mechanical system parameters.
+    tau_L : callable
+        Load torque (Nm) as a function of time, `tau_L(t)`. The default is
         zero, ``lambda t: 0*t``.
 
     """
 
-    # pylint: disable=too-many-instance-attributes
-    def __init__(self, J_M, J_L, K_S, C_S, tau_L_w=None, tau_L_t=None):
-        # pylint: disable=super-init-not-called
-        self.J_M, self.J_L, self.K_S, self.C_S = J_M, J_L, K_S, C_S
-        self.tau_L_w = tau_L_w if tau_L_w is not None else lambda w_L: 0*w_L
-        self.tau_L_t = tau_L_t if tau_L_t is not None else lambda t: 0*t
-        # Initial values
-        self.state = SimpleNamespace(w_M=0, theta_M=0, w_L=0, theta_ML=0)
-        self.inp = SimpleNamespace(tau_M=None)
-        self.out = SimpleNamespace()
+    def __init__(self, par, tau_L=lambda t: 0*t):
+        super().__init__(J=None, B_L=None, tau_L=tau_L)
+        self.par = par
+        self.state = SimpleNamespace(w_M=0, exp_j_theta_M=0, w_L=0, theta_ML=0)
         self.sol_states = SimpleNamespace(
-            w_M=[], theta_M=[], w_L=[], theta_ML=[])
-        self.data = SimpleNamespace()
+            w_M=[], exp_j_theta_M=[], w_L=[], theta_ML=[])
+
+    @property
+    def B_L(self):
+        """Friction coefficient (Nm/(rad/s))."""
+        # Overwrite the base class property
+        if callable(self.par.B_L):
+            return self.par.B_L(np.abs(self.state.w_L.real))
+        return self.par.B_L
 
     def set_outputs(self, t):
         """Set output variables."""
         super().set_outputs(t)
         state, out = self.state, self.out
         out.w_L, out.theta_ML = state.w_L, state.theta_ML
-        out.tau_S = self.K_S*out.theta_ML + self.C_S*(out.w_M - out.w_L)
+        out.tau_L_tot = self.B_L*out.w_L + self.tau_L(t)
+        out.tau_S = self.par.K_S*out.theta_ML + self.par.C_S*(
+            out.w_M - out.w_L)
 
     def rhs(self):
         """Compute state derivatives."""
         state, inp, out = self.state, self.inp, self.out
-        d_w_M = (inp.tau_M - out.tau_S)/self.J_M
-        d_theta_M = state.w_M
-        d_w_L = (out.tau_S - out.tau_L)/self.J_L
+        d_w_M = (inp.tau_M - out.tau_S)/self.par.J_M
+        d_exp_j_theta_M = 1j*state.w_M*state.exp_j_theta_M
+        d_w_L = (out.tau_S - out.tau_L_tot)/self.par.J_L
         d_theta_ML = state.w_M - state.w_L
-        # Wrap the angle, take the real parts
-        state.theta_M = wrap(state.theta_M.real)
-        state.theta_ML = state.theta_ML.real
-        state.w_M, state.w_L = state.w_M.real, state.w_L.real
 
-        return [d_w_M, d_theta_M, d_w_L, d_theta_ML]
+        return [d_w_M, d_exp_j_theta_M, d_w_L, d_theta_ML]
 
     def meas_load_speed(self):
         """Measure the load speed."""
@@ -165,3 +157,69 @@ class TwoMassMechanics(Mechanics):
         super().post_process_states()
         self.data.w_L = self.data.w_L.real
         self.data.theta_ML = self.data.theta_ML.real
+
+    def post_process_with_inputs(self):
+        """Post-process data with inputs."""
+        data = self.data
+        B_L = self.par.B_L(np.abs(data.w_L)) if callable(
+            self.par.B_L) else self.par.B_L
+        data.tau_L_tot = self.tau_L(data.t) + B_L*data.w_L
+
+
+# %%
+class ExternalRotorSpeed(Subsystem):
+    """
+    Integrate the rotor angle from the externally given rotor speed.
+
+    Parameters
+    ----------
+    w_M : callable
+        Rotor speed (rad/s) as a function of time, `w_M(t)`. The default is 
+        zero, ``lambda t: 0*t``.
+
+    """
+
+    def __init__(self, w_M=lambda t: 0*t):
+        super().__init__()
+        self.w_M = w_M
+        self.state = SimpleNamespace(exp_j_theta_M=complex(1))
+        self.out = SimpleNamespace(w_M=w_M(0))  # Needed for direct feedthrough
+        self.sol_states = SimpleNamespace(exp_j_theta_M=[])
+
+    def set_outputs(self, t):
+        """Set output variables."""
+        self.out.w_M = self.w_M(t)
+
+    def rhs(self):
+        """Compute state derivatives."""
+        d_exp_j_theta_M = 1j*self.out.w_M*self.state.exp_j_theta_M
+        return [d_exp_j_theta_M]
+
+    def meas_speed(self):
+        """
+        Measure the rotor speed.
+
+        Returns
+        -------
+        w_M : float
+            Rotor angular speed (mechanical rad/s).
+
+        """
+        return self.out.w_M
+
+    def meas_position(self):
+        """
+        Measure the rotor angle.
+
+        Returns
+        -------
+        theta_M : float
+            Rotor angle (mechanical rad).
+
+        """
+        return np.angle(self.state.exp_j_theta_M)
+
+    def post_process_states(self):
+        """Post-process data."""
+        self.data.theta_M = np.angle(self.data.exp_j_theta_M)
+        self.data.w_M = self.w_M(self.data.t)

--- a/motulator/drive/utils/__init__.py
+++ b/motulator/drive/utils/__init__.py
@@ -1,7 +1,7 @@
 """This module contains utility functions for machine drives."""
 from motulator.drive.utils._helpers import (
     BaseValues, NominalValues, InductionMachineInvGammaPars,
-    InductionMachinePars, SynchronousMachinePars)
+    InductionMachinePars, SynchronousMachinePars, TwoMassMechanicalSystemPars)
 from motulator.drive.utils._plots import plot, plot_extra
 from motulator.drive.utils._flux_maps import (
     import_syre_data, plot_flux_map, plot_flux_vs_current, plot_torque_map)
@@ -13,6 +13,7 @@ __all__ = [
     "InductionMachineInvGammaPars",
     "InductionMachinePars",
     "SynchronousMachinePars",
+    "TwoMassMechanicalSystemPars",
     "plot",
     "plot_extra",
     "import_syre_data",

--- a/motulator/drive/utils/_helpers.py
+++ b/motulator/drive/utils/_helpers.py
@@ -257,3 +257,33 @@ class InductionMachineInvGammaPars(MachinePars):
         R_R, L_sgm, L_M = g**2*par.R_r, g*par.L_ell, g*par.L_s
 
         return cls(R_s=par.R_s, R_R=R_R, L_sgm=L_sgm, L_M=L_M, n_p=par.n_p)
+
+
+# %%
+@dataclass
+class TwoMassMechanicalSystemPars():
+    """
+    Two-mass mechanical system parameters.
+    
+    Parameters
+    ----------
+    J_M : float
+        Motor moment of inertia (kgm²).
+    J_L : float
+        Load moment of inertia (kgm²).
+    K_S : float
+        Shaft torsional stiffness (Nm/rad).
+    C_S : float
+        Shaft torsional damping (Nm/(rad/s)).
+    B_L : float | callable
+        Friction coefficient (Nm/(rad/s)) that can be constant, corresponding 
+        to viscous friction, or an arbitrary function of the load speed. For 
+        example, choosing ``B_L = lambda w_L: k*abs(w_M)`` leads to the 
+        quadratic load torque ``k*w_L**2``. The default is ``B_L = 0``.
+
+    """
+    J_M: float = None
+    J_L: float = None
+    K_S: float = None
+    C_S: float = None
+    B_L: Union[float, Callable] = 0

--- a/motulator/drive/utils/_plots.py
+++ b/motulator/drive/utils/_plots.py
@@ -72,7 +72,9 @@ def plot(sim, base=None, t_span=None):
     except (AttributeError, TypeError):
         pass
     ax1.plot(
-        mdl.data.t, mdl.machine.data.w_m/base.w, label=r"$\omega_\mathrm{m}$")
+        mdl.machine.data.t,
+        mdl.machine.data.w_m/base.w,
+        label=r"$\omega_\mathrm{m}$")
     try:
         ax1.plot(
             ctrl.t,
@@ -86,13 +88,16 @@ def plot(sim, base=None, t_span=None):
     ax1.set_xticklabels([])
 
     # Subplot 2: torques
+    try:
+        ax2.plot(
+            mdl.mechanics.data.t,
+            mdl.mechanics.data.tau_L_tot/base.tau,
+            ":",
+            label=r"$\tau_\mathrm{L,tot}$")
+    except AttributeError:
+        pass
     ax2.plot(
-        mdl.data.t,
-        mdl.mechanics.data.tau_L/base.tau,
-        ":",
-        label=r"$\tau_\mathrm{L}$")
-    ax2.plot(
-        mdl.data.t,
+        mdl.machine.data.t,
         mdl.machine.data.tau_M/base.tau,
         label=r"$\tau_\mathrm{M}$")
     try:
@@ -157,7 +162,7 @@ def plot(sim, base=None, t_span=None):
     # Subplot 5: flux linkages
     if motor_type == "sm":
         ax5.plot(
-            mdl.data.t,
+            mdl.machine.data.t,
             np.abs(mdl.machine.data.psi_ss)/base.psi,
             label=r"$\psi_\mathrm{s}$")
         try:
@@ -180,7 +185,7 @@ def plot(sim, base=None, t_span=None):
 
     else:
         ax5.plot(
-            mdl.data.t,
+            mdl.machine.data.t,
             np.abs(mdl.machine.data.psi_ss)/base.psi,
             label=r"$\psi_\mathrm{s}$")
         ax5.plot(
@@ -261,7 +266,7 @@ def plot_extra(sim, base=None, t_span=None):
 
     # Subplot 1: voltages
     ax1.plot(
-        mdl.data.t,
+        mdl.converter.data.t,
         mdl.converter.data.u_cs.real/base.u,
         label=r"$u_\mathrm{sa}$")
     ax1.plot(
@@ -275,7 +280,7 @@ def plot_extra(sim, base=None, t_span=None):
 
     # Subplot 2: currents
     ax2.plot(
-        mdl.data.t,
+        mdl.machine.data.t,
         complex2abc(mdl.machine.data.i_ss).T/base.i,
         label=[r"$i_\mathrm{sa}$", r"$i_\mathrm{sb}$", r"$i_\mathrm{sc}$"])
     ax2.plot(ctrl.t, ctrl.fbk.i_ss.real/base.i, ds="steps-post")
@@ -303,15 +308,15 @@ def plot_extra(sim, base=None, t_span=None):
 
         # Subplot 1: voltages
         ax1.plot(
-            mdl.data.t,
+            mdl.converter.data.t,
             mdl.converter.data.u_di/base.u,
             label=r"$u_\mathrm{di}$")
         ax1.plot(
-            mdl.data.t,
+            mdl.converter.data.t,
             mdl.converter.data.u_dc/base.u,
             label=r"$u_\mathrm{dc}$")
         ax1.plot(
-            mdl.data.t,
+            mdl.converter.data.t,
             complex2abc(mdl.converter.data.u_g).T/base.u,
             label=r"$u_\mathrm{ga}$")
         ax1.legend()
@@ -320,13 +325,15 @@ def plot_extra(sim, base=None, t_span=None):
 
         # Subplot 2: currents
         ax2.plot(
-            mdl.data.t, mdl.converter.data.i_L/base.i, label=r"$i_\mathrm{L}$")
+            mdl.converter.data.t,
+            mdl.converter.data.i_L/base.i,
+            label=r"$i_\mathrm{L}$")
         ax2.plot(
-            mdl.data.t,
+            mdl.converter.data.t,
             mdl.converter.data.i_dc/base.i,
             label=r"$i_\mathrm{dc}$")
         ax2.plot(
-            mdl.data.t,
+            mdl.converter.data.t,
             mdl.converter.data.i_g.real/base.i,
             label=r"$i_\mathrm{ga}$")
         ax2.legend()


### PR DESCRIPTION
This pull request contains the following changes:

- An unnecessary set_initial_values() method from the simulation module has been removed. 
- The time values corresponding to the solution are now saved to all subsystem. This simplifies post-processing the data after the simulation in some cases (if the class uses functions of the simulation time).
- The ExternalRotorSpeed class has been added to the mechanics module. This allows to simulate drive systems in torque-control mode. One example simulation script has also been added. 
- The parameters of the TwoMassMechanicalSystem class are now provided through the TwoMassMechanicalSystemPars dataclass.
- The complex exponent is used an internal state for rotating angles in system models. This allows to avoid discontinuities originating from the angle wrapping, which could otherwise cause problems to the solver. 
- Notation for the external load torque has been simplified. The speed-dependent load torque term is now parameterized through the speed-dependent friction coefficient (can be constant or callable). 