### PR TITLE
Simplifications in configurations for grid converter systems and controls 

### DIFF
--- a/docs/source/model/grid/grid_volt_source.rst
+++ b/docs/source/model/grid/grid_volt_source.rst
@@ -4,7 +4,8 @@ Three-Phase Voltage Source
 A model for an ideal three-phase voltage source is implemented in the class :class:`motulator.grid.model.ThreePhaseVoltageSource`. The voltage space vector is calculated as a combination of a positive-sequence and optional negative-sequence components as
 
 .. math::
-    \boldsymbol{e}_\mathrm{g}^\mathrm{s} = e_\mathrm{g+}\mathrm{e}^{\mathrm{j}(\vartheta_\mathrm{g} + \phi_\mathrm{+})} + e_\mathrm{g-}\mathrm{e}^{-\mathrm{j}(\vartheta_\mathrm{g} + \phi_\mathrm{-})}
+    \frac{\mathrm{d}\vartheta_\mathrm{g}}{\mathrm{d} t} &= \omega_\mathrm{g} \\
+    \boldsymbol{e}_\mathrm{g}^\mathrm{s} &= e_\mathrm{g+}\mathrm{e}^{\mathrm{j}(\vartheta_\mathrm{g} + \phi_\mathrm{+})} + e_\mathrm{g-}\mathrm{e}^{-\mathrm{j}(\vartheta_\mathrm{g} + \phi_\mathrm{-})}
     :label: grid_voltage_vector
 
-where :math:`e_\mathrm{g+}` and :math:`e_\mathrm{g-}` are the magnitudes of the positive-sequence and negative-sequence components, respectively, :math:`\phi_\mathrm{+}` and :math:`\phi_\mathrm{-}` are the positive-sequence and negative-sequence phase shifts, respectively, and :math:`\vartheta_\mathrm{g}` is the angle obtained by integrating the angular frequency :math:`\omega_\mathrm{g}`. All parameters can be given as time-varying functions to simulate various fault conditions.
+where :math:`e_\mathrm{g+}` and :math:`e_\mathrm{g-}` are the magnitudes of the positive-sequence and negative-sequence components, respectively, and :math:`\phi_\mathrm{+}` and :math:`\phi_\mathrm{-}` are the positive-sequence and negative-sequence phase shifts, respectively. The angle :math:`\vartheta_\mathrm{g}` is obtained by integrating the angular frequency :math:`\omega_\mathrm{g}`. All parameters can be given as time-varying functions to simulate various fault conditions.

--- a/examples/grid/grid_following/plot_gfl_10kva.py
+++ b/examples/grid/grid_following/plot_gfl_10kva.py
@@ -27,7 +27,7 @@ base = BaseValues.from_nominal(nom)
 
 # Filter and grid
 par = ACFilterPars(L_fc=.2*base.L)
-ac_filter = model.ACFilter(par, e_gs0=base.u)
+ac_filter = model.ACFilter(par)
 ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 # Inverter with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)

--- a/examples/grid/grid_following/plot_gfl_10kva.py
+++ b/examples/grid/grid_following/plot_gfl_10kva.py
@@ -2,9 +2,9 @@
 10-kVA converter
 ================
     
-This example simulates a grid-following-controlled converter connected to a
-strong grid. The control system includes a phase-locked loop (PLL) to
-synchronize with the grid, a current reference generator, and a PI-based
+This example simulates a grid-following-controlled converter connected to an L
+filter and a strong grid. The control system includes a phase-locked loop (PLL) 
+to synchronize with the grid, a current reference generator, and a PI-based
 current controller.
 
 """
@@ -12,7 +12,7 @@ current controller.
 # %%
 from motulator.grid import model, control
 from motulator.grid.utils import (
-    BaseValues, FilterPars, GridPars, NominalValues, plot)
+    BaseValues, ACFilterPars, NominalValues, plot)
 # from motulator.grid.utils import plot_voltage_vector
 # import numpy as np
 
@@ -25,34 +25,24 @@ base = BaseValues.from_nominal(nom)
 # %%
 # Configure the system model.
 
-# Grid parameters
-grid_par = GridPars(u_gN=base.u, w_gN=base.w)
-
-# Filter parameters
-filter_par = FilterPars(L_fc=.2*base.L)
-
-# Create AC filter with given parameters
-ac_filter = model.ACFilter(filter_par, grid_par)
-
-# AC grid model with constant voltage magnitude and frequency
-grid_model = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
-
+# Filter and grid
+par = ACFilterPars(L_fc=.2*base.L)
+ac_filter = model.ACFilter(par, e_gs0=base.u)
+ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 # Inverter with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)
 
 # Create system model
-mdl = model.GridConverterSystem(converter, ac_filter, grid_model)
+mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 
 # Uncomment line below to enable the PWM model
-# mdl.pwm = CarrierComparison()
+# mdl.pwm = model.CarrierComparison()
 
 # %%
 # Configure the control system.
 
-# Control configuration parameters
-cfg = control.GFLControlCfg(grid_par, filter_par, max_i=1.5*base.i)
-
-# Create the control system
+cfg = control.GFLControlCfg(
+    L=.2*base.L, nom_u=base.u, nom_w=base.w, max_i=1.5*base.i)
 ctrl = control.GFLControl(cfg)
 
 # %%
@@ -63,9 +53,9 @@ ctrl.ref.p_g = lambda t: (t > .02)*5e3
 ctrl.ref.q_g = lambda t: (t > .04)*4e3
 
 # Uncomment lines below to simulate an unbalanced fault (add negative sequence)
-# mdl.grid_model.par.abs_e_g = .75*base.u
-# mdl.grid_model.par.abs_e_g_neg = .25*base.u
-# mdl.grid_model.par.phi_neg = -np.pi/3
+# mdl.ac_source.par.abs_e_g = .75*base.u
+# mdl.ac_source.par.abs_e_g_neg = .25*base.u
+# mdl.ac_source.par.phi_neg = -np.pi/3
 
 # %%
 # Create the simulation object and simulate it.

--- a/examples/grid/grid_following/plot_gfl_dc_bus_10kva.py
+++ b/examples/grid/grid_following/plot_gfl_dc_bus_10kva.py
@@ -25,7 +25,7 @@ base = BaseValues.from_nominal(nom)
 
 # Filter and grid
 par = ACFilterPars(L_fc=.2*base.L)
-ac_filter = model.ACFilter(par, e_gs0=base.u)
+ac_filter = model.ACFilter(par)
 ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 # Converter model with the DC-bus dynamics
 converter = model.VoltageSourceConverter(u_dc=600, C_dc=1e-3)

--- a/examples/grid/grid_following/plot_gfl_dc_bus_10kva.py
+++ b/examples/grid/grid_following/plot_gfl_dc_bus_10kva.py
@@ -12,7 +12,7 @@ grid, a current reference generator, and a PI-type current controller.
 # %%
 from motulator.grid import model, control
 from motulator.grid.utils import (
-    BaseValues, FilterPars, GridPars, NominalValues, plot)
+    BaseValues, ACFilterPars, NominalValues, plot)
 
 # %%
 # Compute base values based on the nominal values.
@@ -23,29 +23,22 @@ base = BaseValues.from_nominal(nom)
 # %%
 # Configure the system model.
 
-# Grid parameters
-grid_par = GridPars(u_gN=base.u, w_gN=base.w)
-
-# Filter parameters
-filter_par = FilterPars(L_fc=.2*base.L)
-
-# Create AC filter with given parameters
-ac_filter = model.ACFilter(filter_par, grid_par)
-
-# AC grid model with constant voltage magnitude and frequency
-grid_model = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
-
-# Inverter model with DC-bus dynamics included
+# Filter and grid
+par = ACFilterPars(L_fc=.2*base.L)
+ac_filter = model.ACFilter(par, e_gs0=base.u)
+ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
+# Converter model with the DC-bus dynamics
 converter = model.VoltageSourceConverter(u_dc=600, C_dc=1e-3)
 
 # Create system model
-mdl = model.GridConverterSystem(converter, ac_filter, grid_model)
+mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 
 # %%
 # Configure the control system.
 
 # Create the control system
-cfg = control.GFLControlCfg(grid_par, filter_par, max_i=1.5*base.i, C_dc=1e-3)
+cfg = control.GFLControlCfg(
+    L=.2*base.L, nom_u=base.u, nom_w=base.w, max_i=1.5*base.i, C_dc=1e-3)
 ctrl = control.GFLControl(cfg)
 
 # Add the DC-bus voltage controller to the control system

--- a/examples/grid/grid_following/plot_gfl_lcl_10kva.py
+++ b/examples/grid/grid_following/plot_gfl_lcl_10kva.py
@@ -5,14 +5,15 @@
 This example simulates a grid-following-controlled converter connected to a
 strong grid through an LCL filter. The control system includes a phase-locked
 loop (PLL) to synchronize with the grid, a current reference generator, and a
-PI-type current controller.
+PI-type current controller. The dynamics of the LCL filter are not taken into
+account in the control system.
 
 """
 
 # %%
 from motulator.grid import model, control
 from motulator.grid.utils import (
-    BaseValues, FilterPars, GridPars, NominalValues, plot)
+    BaseValues, ACFilterPars, NominalValues, plot)
 
 # %%
 # Compute base values based on the nominal values.
@@ -23,29 +24,21 @@ base = BaseValues.from_nominal(nom)
 # %%
 # Configure the system model.
 
-# Grid and filter parameters
-grid_par = GridPars(u_gN=base.u, w_gN=base.w)
-filter_par = FilterPars(L_fc=.073*base.L, L_fg=.073*base.L, C_f=.043*base.C)
-
-# DC-bus parameters
-ac_filter = model.ACFilter(filter_par, grid_par)
-
-# AC grid model with constant voltage magnitude and frequency
-grid_model = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
-
+# Grid and filter
+par = ACFilterPars(L_fc=.073*base.L, L_fg=.073*base.L, C_f=.043*base.C)
+ac_filter = model.ACFilter(par, e_gs0=base.u)
+ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 # Inverter model with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)
 
 # Create system model
-mdl = model.GridConverterSystem(converter, ac_filter, grid_model)
+mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 
 # %%
 # Configure the control system.
 
-# Control parameters
-cfg = control.GFLControlCfg(grid_par, filter_par, max_i=1.5*base.i)
-
-# Create the control system
+cfg = control.GFLControlCfg(
+    L=.073*base.L, nom_u=base.u, nom_w=base.w, max_i=1.5*base.i)
 ctrl = control.GFLControl(cfg)
 
 # %%

--- a/examples/grid/grid_following/plot_gfl_lcl_10kva.py
+++ b/examples/grid/grid_following/plot_gfl_lcl_10kva.py
@@ -25,8 +25,9 @@ base = BaseValues.from_nominal(nom)
 # Configure the system model.
 
 # Grid and filter
-par = ACFilterPars(L_fc=.073*base.L, L_fg=.073*base.L, C_f=.043*base.C)
-ac_filter = model.ACFilter(par, e_gs0=base.u)
+par = ACFilterPars(
+    L_fc=.073*base.L, L_fg=.073*base.L, C_f=.043*base.C, u_fs0=base.u)
+ac_filter = model.ACFilter(par)
 ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 # Inverter model with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)

--- a/examples/grid/grid_forming/plot_gfm_obs_13kva.py
+++ b/examples/grid/grid_forming/plot_gfm_obs_13kva.py
@@ -12,7 +12,7 @@ observer. A transparent current controller is included for current limitation.
 # %%
 from motulator.grid import model, control
 from motulator.grid.utils import (
-    BaseValues, FilterPars, GridPars, NominalValues, plot)
+    BaseValues, ACFilterPars, NominalValues, plot)
 
 # %%
 # Compute base values based on the nominal values.
@@ -23,35 +23,30 @@ base = BaseValues.from_nominal(nom)
 # %%
 # Configure the system model.
 
-# Grid parameters
-grid_par = GridPars(u_gN=base.u, w_gN=base.w, L_g=.74*base.L)
+# Filter and grid parameters
+par = ACFilterPars(L_fc=.15*base.L, R_fc=.05*base.Z, L_g=.74*base.L)
 # Uncomment the line below to simulate a strong grid
-# grid_par.L_g = 0
-
-# Filter parameters
-filter_par = FilterPars(L_fc=.15*base.L, R_fc=.05*base.Z)
-
-# Create AC filter with given parameters
-ac_filter = model.ACFilter(filter_par, grid_par)
-
-# Grid voltage source with constant frequency and voltage magnitude
-grid_model = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
-
+# par.L_g = 0
+ac_filter = model.ACFilter(par, e_gs0=base.u)
+ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 # Inverter with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)
 
 # Create system model
-mdl = model.GridConverterSystem(converter, ac_filter, grid_model)
+mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 
 # %%
 # Configure the control system.
 
-# Estimates for the grid parameters, grid inductance estimate is left at 0
-grid_par_est = GridPars(u_gN=base.u, w_gN=base.w, L_g=.2*base.L)
-
 # Set the configuration parameters
 cfg = control.ObserverBasedGFMControlCfg(
-    grid_par_est, filter_par, max_i=1.3*base.i, T_s=100e-6, R_a=.2*base.Z)
+    L=.35*base.L,
+    R=.05*base.Z,
+    nom_u=base.u,
+    nom_w=base.w,
+    max_i=1.3*base.i,
+    T_s=100e-6,
+    R_a=.2*base.Z)
 
 # Create the control system
 ctrl = control.ObserverBasedGFMControl(cfg)
@@ -70,7 +65,7 @@ ctrl.ref.p_g = lambda t: ((t > .2)/3 + (t > .5)/3 + (t > .8)/3 -
 # ctrl.ref.p_g = lambda t: ((t > .2) - (t > .7)*2 + (t > 1.2))*nom.P
 
 # Uncomment lines below to simulate a grid voltage sag with constant ref.p_g
-# mdl.grid_model.par.abs_e_g = lambda t: (1 - (t > .2)*.8 + (t > 1)*.8)*base.u
+# mdl.ac_source.par.abs_e_g = lambda t: (1 - (t > .2)*.8 + (t > 1)*.8)*base.u
 # ctrl.ref.p_g = lambda t: nom.P
 
 # %%

--- a/examples/grid/grid_forming/plot_gfm_obs_13kva.py
+++ b/examples/grid/grid_forming/plot_gfm_obs_13kva.py
@@ -25,9 +25,8 @@ base = BaseValues.from_nominal(nom)
 
 # Filter and grid parameters
 par = ACFilterPars(L_fc=.15*base.L, R_fc=.05*base.Z, L_g=.74*base.L)
-# Uncomment the line below to simulate a strong grid
-# par.L_g = 0
-ac_filter = model.ACFilter(par, e_gs0=base.u)
+# par.L_g = 0 # Uncomment this line to simulate a strong grid
+ac_filter = model.ACFilter(par)
 ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 # Inverter with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)

--- a/examples/grid/grid_forming/plot_gfm_rfpsc_13kva.py
+++ b/examples/grid/grid_forming/plot_gfm_rfpsc_13kva.py
@@ -21,17 +21,12 @@ base = BaseValues.from_nominal(nom)
 # %%
 # Configure the system model.
 
-# Filter and grid parameters
+# Filter and grid
 par = ACFilterPars(L_fc=.15*base.L, L_g=.74*base.L)
-# Uncomment line below to simulate a strong grid
-# par.L_g = 0
-
-# Create AC filter with given parameters
-ac_filter = model.ACFilter(par, e_gs0=base.u)
-
+# par.L_g = 0  # Uncomment this line to simulate a strong grid
+ac_filter = model.ACFilter(par)
 # Grid voltage source with constant frequency and voltage magnitude
 ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
-
 # Inverter with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)
 

--- a/examples/grid/grid_forming/plot_gfm_rfpsc_13kva.py
+++ b/examples/grid/grid_forming/plot_gfm_rfpsc_13kva.py
@@ -10,7 +10,7 @@ This example simulates reference-feedforward power-synchronization control
 # %%
 from motulator.grid import model, control
 from motulator.grid.utils import (
-    BaseValues, FilterPars, GridPars, NominalValues, plot)
+    BaseValues, ACFilterPars, NominalValues, plot)
 
 # %%
 # Compute base values based on the nominal values.
@@ -21,32 +21,29 @@ base = BaseValues.from_nominal(nom)
 # %%
 # Configure the system model.
 
-# Grid parameters
-grid_par = GridPars(u_gN=base.u, w_gN=base.w, L_g=.74*base.L)
+# Filter and grid parameters
+par = ACFilterPars(L_fc=.15*base.L, L_g=.74*base.L)
 # Uncomment line below to simulate a strong grid
-# grid_par.L_g = 0
-
-# Filter parameters
-filter_par = FilterPars(L_fc=.15*base.L)
+# par.L_g = 0
 
 # Create AC filter with given parameters
-ac_filter = model.ACFilter(filter_par, grid_par)
+ac_filter = model.ACFilter(par, e_gs0=base.u)
 
 # Grid voltage source with constant frequency and voltage magnitude
-grid_model = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
+ac_source = model.ThreePhaseVoltageSource(w_g=base.w, abs_e_g=base.u)
 
 # Inverter with constant DC voltage
 converter = model.VoltageSourceConverter(u_dc=650)
 
 # Create system model
-mdl = model.GridConverterSystem(converter, ac_filter, grid_model)
+mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 
 # %%
 # Configure the control system.
 
 # Control configuration parameters
 cfg = control.RFPSCControlCfg(
-    grid_par, filter_par, max_i=1.3*base.i, T_s=100e-6, R_a=.2*base.Z)
+    nom_u=base.u, nom_w=base.w, max_i=1.3*base.i, T_s=100e-6, R_a=.2*base.Z)
 
 # Create the control system
 ctrl = control.RFPSCControl(cfg)

--- a/motulator/common/model/_simulation.py
+++ b/motulator/common/model/_simulation.py
@@ -187,14 +187,15 @@ class Simulation:
     """
     Simulation environment.
 
-    Each simulation object has a system model object and a controller object.
+    Each simulation object has a system model object and a control system 
+    object.
 
     Parameters
     ----------
     mdl : Model 
         Continuous-time system model.
     ctrl : ControlSystem
-        Discrete-time controller.
+        Discrete-time control system.
 
     """
 
@@ -204,7 +205,7 @@ class Simulation:
 
     def simulate(self, t_stop=1, max_step=np.inf):
         """
-        Solve the continuous-time model and call the discrete-time controller.
+        Solve the continuous-time system model and call the control system.
 
         Parameters
         ----------
@@ -359,6 +360,9 @@ class Model(ABC):
                 # Check if the state derivative exists before adding it
                 if subsystem_rhs is not None:
                     rhs_list += subsystem_rhs
+
+        ################## Set the outputs for the interconnections and for the rhs
+        #self.post_set_outputs(t)
 
         # List of state derivatives
         return rhs_list

--- a/motulator/drive/utils/_helpers.py
+++ b/motulator/drive/utils/_helpers.py
@@ -28,7 +28,6 @@ class NominalValues:
         Torque (Nm).
 
     """
-
     U: float
     I: float
     f: float

--- a/motulator/grid/control/_common.py
+++ b/motulator/grid/control/_common.py
@@ -102,8 +102,6 @@ class GridConverterControlSystem(ControlSystem, ABC):
 
     Parameters
     ----------
-    grid_par : GridPars
-        Grid model parameters.
     C_dc : float, optional
         DC-bus capacitance (F). The default is None.
     T_s : float
@@ -132,9 +130,8 @@ class GridConverterControlSystem(ControlSystem, ABC):
 
     """
 
-    def __init__(self, grid_par, C_dc, T_s):
+    def __init__(self, C_dc, T_s):
         super().__init__(T_s)
-        self.grid_par = grid_par
         self.C_dc = C_dc
         self.dc_bus_volt_ctrl = None
         self.pwm = PWM(overmodulation="MPE")

--- a/motulator/grid/control/_power_synchronization.py
+++ b/motulator/grid/control/_power_synchronization.py
@@ -7,7 +7,6 @@ import numpy as np
 from motulator.common.utils import wrap
 from motulator.grid.control._common import (
     CurrentLimiter, GridConverterControlSystem)
-from motulator.grid.utils import FilterPars, GridPars
 
 
 # %%
@@ -18,14 +17,14 @@ class RFPSCControlCfg:
 
     Parameters
     ----------
-    grid_par : GridPars
-        Grid model parameters.
-    filter_par : FilterPars
-        Filter model parameters.
+    nom_u : float
+        Nominal grid voltage (V), line-to-neutral peak value.
+    nom_w : float
+        Nominal grid frequency (rad/s).
     max_i : float
-        Maximum current modulus (A).
-    R_a : float
-        Damping resistance (Ω).
+        Maximum current (A), peak value.
+    R_a : float, optional
+        Active resistance (Ω). The default is 0.25*num_u/max_i.
     T_s : float, optional
         Sampling period of the controller (s). The default is 100e-6.
     w_b : float, optional
@@ -34,18 +33,18 @@ class RFPSCControlCfg:
         DC-bus capacitance (F). The default is None.
 
     """
-
-    grid_par: GridPars
-    filter_par: FilterPars
+    nom_u: float
+    nom_w: float
     max_i: float
-    R_a: float
+    R_a: float = None
     T_s: float = 100e-6
     w_b: float = 2*np.pi*5
     C_dc: float = None
 
     def __post_init__(self):
-        par = self.grid_par
-        self.k_p_psc = par.w_gN*self.R_a/(1.5*par.u_gN*par.u_gN)
+        if self.R_a is None:
+            self.R_a = .25*self.nom_u/self.max_i
+        self.k_p_psc = self.nom_w*self.R_a/(1.5*self.nom_u**2)
 
 
 # %%
@@ -70,7 +69,7 @@ class RFPSCControl(GridConverterControlSystem):
     """
 
     def __init__(self, cfg):
-        super().__init__(cfg.grid_par, cfg.C_dc, cfg.T_s)
+        super().__init__(cfg.C_dc, cfg.T_s)
         self.cfg = cfg
         self.current_limiter = CurrentLimiter(cfg.max_i)
         self.ref.q_g = 0
@@ -91,7 +90,7 @@ class RFPSCControl(GridConverterControlSystem):
 
     def output(self, fbk):
         """Extend the base class method."""
-        par, cfg = self.grid_par, self.cfg
+        cfg = self.cfg
 
         # Get the reference signals
         ref = super().output(fbk)
@@ -100,7 +99,7 @@ class RFPSCControl(GridConverterControlSystem):
             self.ref.v_c) else self.ref.v_c
 
         # Calculation of power droop
-        fbk.w_c = par.w_gN + cfg.k_p_psc*(ref.p_g - fbk.p_c)
+        fbk.w_c = cfg.nom_w + cfg.k_p_psc*(ref.p_g - fbk.p_c)
 
         # Optionally, use of reference feedforward for d-axis current
         ref.i_c = ref.p_g/(1.5*ref.v_c) + 1j*fbk.i_c_flt.imag

--- a/motulator/grid/model/_ac_filter.py
+++ b/motulator/grid/model/_ac_filter.py
@@ -1,5 +1,5 @@
 """
-Grid and AC filter impedance models.
+AC filter and grid impedance models.
 
 This module contains continuous-time models for subsystems comprising an AC 
 filter and a grid impedance between the converter and grid voltage sources. The 
@@ -10,7 +10,6 @@ from types import SimpleNamespace
 
 from motulator.common.model import Subsystem
 from motulator.common.utils import complex2abc
-from motulator.grid.utils import FilterPars
 
 
 # %%
@@ -25,18 +24,18 @@ class ACFilter(Subsystem):
 
     Parameters
     ----------
-    filter_par : FilterPars
+    par : ACFilterPars
         Filter model parameters.
-    grid_par : GridPars
-        Grid model parameters.
-        
+    e_gs0 : complex
+        Initial grid voltage (V) in stationary coordinates. 
+
     """
 
-    def __new__(cls, filter_par: FilterPars, _):
-        if filter_par.C_f > 0:
-            if filter_par.L_fg > 0:
+    def __new__(cls, par, e_gs0):
+        if par.C_f > 0:
+            if par.L_fg > 0:
                 return super().__new__(LCLFilter)
-            raise ValueError("L_fg must be specified for LCL filter.")
+            raise ValueError("L_fg must be specified for the LCL filter.")
         return super().__new__(LFilter)
 
     def meas_currents(self):
@@ -79,34 +78,29 @@ class LFilter(ACFilter):
 
     Parameters
     ----------
-    grid_par : GridPars
-        Grid model parameters. The following parameters are needed:
-
-            L_g : float
-                Grid inductance (H).
-            R_g : float, optional
-                Series resistance (Ω). The default is 0.
-
-    filter_par : FilterPars
+    par : ACFilterPars
         Filter model parameters. The following parameters are needed:
 
             L_fc : float
                 Filter inductance (H).
             R_fc : float, optional
-                Series resistance (Ω). The default is 0.
+                Series resistance (Ω).
+            L_g : float
+                Grid inductance (H).
+            R_g : float, optional
+                Series resistance (Ω). 
+            e_gs0 : complex
+                Initial PCC voltage (V) in stationary coordinates. 
 
     """
 
-    def __init__(self, filter_par, grid_par):
+    def __init__(self, par, e_gs0):
         super().__init__()
         self.par = SimpleNamespace(
-            L_f=filter_par.L_fc,
-            R_f=filter_par.R_fc,
-            L_g=grid_par.L_g,
-            R_g=grid_par.R_g)
-        self.inp = SimpleNamespace(u_cs=0j, e_gs=grid_par.u_gN + 0j)
-        # For direct feedthrough
-        self.out = SimpleNamespace(u_gs=grid_par.u_gN + 0j)
+            L_f=par.L_fc, R_f=par.R_fc, L_g=par.L_g, R_g=par.R_g)
+        # For direct feedthrough through u_gs
+        self.inp = SimpleNamespace(u_cs=complex(e_gs0), e_gs=complex(e_gs0))
+        self.out = SimpleNamespace(u_gs=complex(e_gs0))
         self.state = SimpleNamespace(i_cs=0j)
         self.sol_states = SimpleNamespace(i_cs=[])
 
@@ -114,9 +108,8 @@ class LFilter(ACFilter):
         """Set output variables."""
         state, par, inp, out = self.state, self.par, self.inp, self.out
         u_gs = (
-            par.L_g*inp.u_cs + par.L_f*inp.e_gs +
-            (par.R_g*par.L_f - par.R_f*par.L_g)*state.i_cs)/(
-                par.L_g + par.L_f)
+            par.L_g*(inp.u_cs - par.R_f*state.i_cs) + par.L_f*
+            (inp.e_gs + par.R_g*state.i_cs))/(par.L_g + par.L_f)
         out.i_cs, out.i_gs, out.u_gs = state.i_cs, state.i_cs, u_gs
 
     def rhs(self):
@@ -133,11 +126,10 @@ class LFilter(ACFilter):
 
     def post_process_with_inputs(self):
         """Post-process data with inputs."""
-        data = self.data
+        data, par = self.data, self.par
         data.u_gs = (
-            self.par.L_g*data.u_cs + self.par.L_f*data.e_gs +
-            (self.par.R_g*self.par.L_f - self.par.R_f*self.par.L_g)*
-            data.i_cs)/(self.par.L_g + self.par.L_f)
+            par.L_g*(data.u_cs - par.R_f*data.i_cs) + par.L_f*
+            (data.e_gs + par.R_g*data.i_cs))/(par.L_g + par.L_f)
 
 
 # %%
@@ -152,31 +144,24 @@ class LCLFilter(ACFilter):
 
     Parameters
     ----------
-    grid_par : GridPars
-        Grid model parameters. 
-    filter_par : FilterPars
+    par : ACFilterPars
         Filter model parameters.
 
     """
 
-    def __init__(self, filter_par, grid_par):
+    def __init__(self, par, e_gs0):
         super().__init__()
         self.par = SimpleNamespace(
-            L_fc=filter_par.L_fc,
-            R_fc=filter_par.R_fc,
-            L_fg=filter_par.L_fg,
-            R_fg=filter_par.R_fg,
-            C_f=filter_par.C_f,
-            L_g=grid_par.L_g,
-            R_g=grid_par.R_g,
-        )
-        self.inp = SimpleNamespace(u_cs=0 + 0j, e_gs=grid_par.u_gN + 0j)
-        self.out = SimpleNamespace(u_gs=grid_par.u_gN + 0j)
-        self.state = SimpleNamespace(
-            i_cs=0j,
-            u_fs=grid_par.u_gN + 0j,
-            i_gs=0j,
-        )
+            L_fc=par.L_fc,
+            R_fc=par.R_fc,
+            L_fg=par.L_fg,
+            R_fg=par.R_fg,
+            C_f=par.C_f,
+            L_g=par.L_g,
+            R_g=par.R_g)
+        self.inp = SimpleNamespace(u_cs=complex(e_gs0), e_gs=complex(e_gs0))
+        self.out = SimpleNamespace(u_gs=complex(e_gs0))
+        self.state = SimpleNamespace(i_cs=0j, u_fs=complex(e_gs0), i_gs=0j)
         self.sol_states = SimpleNamespace(i_cs=[], u_fs=[], i_gs=[])
 
     def set_outputs(self, _):

--- a/motulator/grid/model/_converter_system.py
+++ b/motulator/grid/model/_converter_system.py
@@ -20,23 +20,23 @@ class GridConverterSystem(Model):
         Converter model.
     ac_filter : LFilter | LCLFilter
         Dynamic model for converter output filter and grid impedance.
-    grid_model : ThreePhaseVoltageSource
+    ac_source : ThreePhaseVoltageSource
         Three-phase grid voltage source model.
 
     """
 
-    def __init__(self, converter=None, ac_filter=None, grid_model=None):
+    def __init__(self, converter=None, ac_filter=None, ac_source=None):
         super().__init__()
         self.converter = converter
         self.ac_filter = ac_filter
-        self.grid_model = grid_model
-        self.subsystems = [self.converter, self.ac_filter, self.grid_model]
+        self.ac_source = ac_source
+        self.subsystems = [self.converter, self.ac_filter, self.ac_source]
 
     def interconnect(self, _):
         """Interconnect the subsystems."""
         self.converter.inp.i_cs = self.ac_filter.out.i_cs
         self.ac_filter.inp.u_cs = self.converter.out.u_cs
-        self.ac_filter.inp.e_gs = self.grid_model.out.e_gs
+        self.ac_filter.inp.e_gs = self.ac_source.out.e_gs
 
     def post_process(self):
         """Post-process the solution."""
@@ -45,6 +45,6 @@ class GridConverterSystem(Model):
         # Add the input data to the subsystems for post-processing
         self.converter.data.i_cs = self.ac_filter.data.i_cs
         self.ac_filter.data.u_cs = self.converter.data.u_cs
-        self.ac_filter.data.e_gs = self.grid_model.data.e_gs
+        self.ac_filter.data.e_gs = self.ac_source.data.e_gs
         # Post-processing based on the inputs and the states
         super().post_process_with_inputs()

--- a/motulator/grid/utils/__init__.py
+++ b/motulator/grid/utils/__init__.py
@@ -2,12 +2,11 @@
 
 from motulator.common.utils._utils import BaseValues, NominalValues, Step
 from motulator.grid.utils._plots import plot, plot_voltage_vector
-from motulator.grid.utils._utils import FilterPars, GridPars
+from motulator.grid.utils._utils import ACFilterPars
 
 __all__ = [
     "BaseValues",
-    "FilterPars",
-    "GridPars",
+    "ACFilterPars",
     "NominalValues",
     "plot",
     "plot_voltage_vector",

--- a/motulator/grid/utils/_plots.py
+++ b/motulator/grid/utils/_plots.py
@@ -57,7 +57,7 @@ def plot(sim, base=None, plot_pcc_voltage=True, plot_w=False, t_span=None):
 
     # Three-phase quantities
     i_g_abc = complex2abc(mdl.ac_filter.data.i_gs).T
-    e_g_abc = complex2abc(mdl.grid_model.data.e_gs).T
+    e_g_abc = complex2abc(mdl.ac_source.data.e_gs).T
     u_g_abc = complex2abc(mdl.ac_filter.data.u_gs).T
 
     # Calculation of active and reactive powers
@@ -81,7 +81,7 @@ def plot(sim, base=None, plot_pcc_voltage=True, plot_w=False, t_span=None):
         if not plot_pcc_voltage:
             # Subplot 1: Grid voltage
             ax1.plot(
-                mdl.grid_model.data.t,
+                mdl.ac_source.data.t,
                 e_g_abc/base.u,
                 label=[
                     r"$e_\mathrm{ga}$", r"$e_\mathrm{gb}$", r"$e_\mathrm{gc}$"
@@ -122,8 +122,8 @@ def plot(sim, base=None, plot_pcc_voltage=True, plot_w=False, t_span=None):
     if plot_w:
         # Subplot 3: Grid and converter frequencies
         ax3.plot(
-            mdl.grid_model.data.t,
-            mdl.grid_model.data.w_g/base.w,
+            mdl.ac_source.data.t,
+            mdl.ac_source.data.w_g/base.w,
             label=r"$\omega_\mathrm{g}$")
         ax3.plot(
             ctrl.t,
@@ -136,8 +136,8 @@ def plot(sim, base=None, plot_pcc_voltage=True, plot_w=False, t_span=None):
     else:
         # Subplot 3: Phase angles
         ax3.plot(
-            mdl.grid_model.data.t,
-            mdl.grid_model.data.theta_g,
+            mdl.ac_source.data.t,
+            mdl.ac_source.data.theta_g,
             label=r"$\theta_\mathrm{g}$")
         ax3.plot(
             ctrl.t,
@@ -233,8 +233,8 @@ def plot(sim, base=None, plot_pcc_voltage=True, plot_w=False, t_span=None):
             label=r"$\hat{v}_\mathrm{c}$",
             ds="steps-post")
         ax3.plot(
-            mdl.grid_model.data.t,
-            np.abs(mdl.grid_model.data.e_gs/base.u),
+            mdl.ac_source.data.t,
+            np.abs(mdl.ac_source.data.e_gs/base.u),
             "k--",
             label=r"$e_\mathrm{g}$")
     else:
@@ -250,8 +250,8 @@ def plot(sim, base=None, plot_pcc_voltage=True, plot_w=False, t_span=None):
             label=r"$u_\mathrm{cq}$",
             ds="steps-post")
         ax3.plot(
-            mdl.grid_model.data.t,
-            np.abs(mdl.grid_model.data.e_gs)/base.u,
+            mdl.ac_source.data.t,
+            np.abs(mdl.ac_source.data.e_gs)/base.u,
             "k--",
             label=r"$e_\mathrm{g}$")
     ax3.legend()
@@ -301,8 +301,8 @@ def plot_voltage_vector(sim, base=None):
     # Plot the grid voltage vector in the complex plane
     _, ax = plt.subplots()
     ax.plot(
-        mdl.grid_model.data.e_gs.real/base.u,
-        mdl.grid_model.data.e_gs.imag/base.u,
+        mdl.ac_source.data.e_gs.real/base.u,
+        mdl.ac_source.data.e_gs.imag/base.u,
         label="Grid voltage")
     ax.axhline(0, color="k")
     ax.axvline(0, color="k")

--- a/motulator/grid/utils/_utils.py
+++ b/motulator/grid/utils/_utils.py
@@ -1,50 +1,30 @@
 """Common dataclasses usable in models and control of grid converters."""
 
-from abc import ABC
 from dataclasses import dataclass
-
-
-@dataclass
-class GridPars(ABC):
-    """
-    Class for grid parameters
-
-    Parameters
-    ----------
-    u_gN : float
-        Nominal grid voltage, phase-to-ground peak value (V).
-    w_gN : float
-        Nominal grid angular frequency (rad/s).
-    L_g : float, optional
-        Grid inductance (H). The default is 0.
-    R_g : float, optional
-        Grid resistance (Ω). The default is 0.
-
-    """
-    u_gN: float = None
-    w_gN: float = None
-    L_g: float = 0
-    R_g: float = 0
 
 
 # %%
 @dataclass
-class FilterPars(ABC):
+class ACFilterPars:
     """
-    Filter parameters
+    AC filter and grid impedance parameters.
 
     Parameters
     ----------
     L_fc : float
-        Converter-side inductance of the filter (H).
+        Converter-side filter inductance (H).
     L_fg : float, optional
-        Grid-side inductance of the filter (H). The default is 0.
+        Grid-side filter inductance (H). The default is 0.
     C_f : float, optional
         Filter capacitance (F). The default is 0.
     R_fc : float, optional
-        Converter-side series resistance (Ω). The default is 0.
+        Series resistance (Ω) of the converter-side inductor. The default is 0.
     R_fg : float, optional
-        Grid-side series resistance (Ω). The default is 0.
+        Series resistance (Ω) of the grid-side inductor. The default is 0.
+    L_g : float, optional
+        Grid inductance (H). The default is 0.
+    R_g : float, optional
+        Grid resistance (Ω). The default is 0.
 
     """
     L_fc: float
@@ -52,3 +32,5 @@ class FilterPars(ABC):
     C_f: float = 0
     R_fc: float = 0
     R_fg: float = 0
+    L_g: float = 0
+    R_g: float = 0

--- a/motulator/grid/utils/_utils.py
+++ b/motulator/grid/utils/_utils.py
@@ -25,6 +25,9 @@ class ACFilterPars:
         Grid inductance (H). The default is 0.
     R_g : float, optional
         Grid resistance (Ω). The default is 0.
+    u_fs0 : float, optional
+        Initial value of the filter capacitor voltage (V). Needed in the case 
+        of an LCL filter.
 
     """
     L_fc: float
@@ -34,3 +37,4 @@ class ACFilterPars:
     R_fg: float = 0
     L_g: float = 0
     R_g: float = 0
+    u_fs0: float = None


### PR DESCRIPTION
- The dataclass GridPars is removed. 
- Naming of a three-phase voltage source object is changed (grid_model -> ac_source). 
- Parametrization of grid converter system models is simplified in the example scripts. 
- Control configuration is also simplified to avoid providing unused parameters to grid converter control systems.