### PR TITLE
Fix GH action permission

### DIFF
--- a/.github/workflows/update_gh-pages.yml
+++ b/.github/workflows/update_gh-pages.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build-doc:
     runs-on: ubuntu-latest # Easy to use GitHub hosted runner, self hosted runner would require manual configurations


### PR DESCRIPTION
This PR fixes the permissions for `update_gh-pages.yml` action.

@mhinkkan this should fix the behaviour that lead to #162 