### PR TITLE
Fix current reference calculation, clarify interfaces

### DIFF
--- a/motulator/common/model/_simulation.py
+++ b/motulator/common/model/_simulation.py
@@ -109,12 +109,17 @@ class Simulation:
         """
         try:
             # Initialize outputs based on initial states
-            self.mdl.set_outputs(0)  # Set t = 0 for initialization
+            self.mdl.set_outputs(0.0)
 
             # Main simulation loop
             progress_bar = None
             if self.show_progress:
-                progress_bar = tqdm(total=t_stop, desc="Simulation", unit="s")
+                progress_bar = tqdm(
+                    total=t_stop,
+                    desc="Simulation",
+                    unit="s",
+                    bar_format="{l_bar}{bar}| {n:.2f}/{total:.2f} {unit}",
+                )
 
             def update_progress() -> None:
                 if progress_bar is not None:

--- a/motulator/drive/control/_im_current_vector.py
+++ b/motulator/drive/control/_im_current_vector.py
@@ -266,11 +266,11 @@ class CurrentVectorController:
 
     def get_feedback(self, meas: Measurements) -> ObserverOutputs:
         """Get the feedback signals."""
-        u_s_ab = self.pwm.get_realized_voltage()
+        u_c_ab = self.pwm.get_realized_voltage()
         if self.sensorless:
-            fbk = self.observer.compute_output(meas, u_s_ab)
+            fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab)
         else:
-            fbk = self.observer.compute_output(meas, u_s_ab, meas.w_M)
+            fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab, meas.w_M)
         fbk.u_dc = meas.u_dc
         return fbk
 

--- a/motulator/drive/control/_im_flux_vector.py
+++ b/motulator/drive/control/_im_flux_vector.py
@@ -311,11 +311,11 @@ class FluxVectorController:
 
     def get_feedback(self, meas: Measurements) -> ObserverOutputs:
         """Get feedback signals."""
-        u_s_ab = self.pwm.get_realized_voltage()
+        u_c_ab = self.pwm.get_realized_voltage()
         if self.sensorless:
-            fbk = self.observer.compute_output(meas, u_s_ab)
+            fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab)
         else:
-            fbk = self.observer.compute_output(meas, u_s_ab, meas.w_M)
+            fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab, meas.w_M)
         fbk.u_dc = meas.u_dc
         return fbk
 
@@ -418,8 +418,8 @@ class ObserverBasedVHzController:
 
     def get_feedback(self, w_M_ref: float, meas: Measurements) -> ObserverOutputs:
         """Get feedback signals."""
-        u_s_ab = self.pwm.get_realized_voltage()
-        fbk = self.observer.compute_output(meas, u_s_ab, w_M_ref)
+        u_c_ab = self.pwm.get_realized_voltage()
+        fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab, w_M_ref)
         fbk.u_dc = meas.u_dc
         return fbk
 

--- a/motulator/drive/control/_sm_current_vector.py
+++ b/motulator/drive/control/_sm_current_vector.py
@@ -166,11 +166,13 @@ class CurrentVectorController:
 
     def get_feedback(self, meas: Measurements) -> ObserverOutputs:
         """Get feedback signals."""
-        u_s_ab = self.pwm.get_realized_voltage()
+        u_c_ab = self.pwm.get_realized_voltage()
         if self.observer.sensorless:
-            fbk = self.observer.compute_output(meas, u_s_ab)
+            fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab)
         else:
-            fbk = self.observer.compute_output(meas, u_s_ab, meas.w_M)
+            fbk = self.observer.compute_output(
+                u_c_ab, meas.i_c_ab, meas.w_M, meas.theta_M
+            )
         fbk.u_dc = meas.u_dc
         return fbk
 

--- a/motulator/drive/control/_sm_flux_vector.py
+++ b/motulator/drive/control/_sm_flux_vector.py
@@ -237,11 +237,13 @@ class FluxVectorController:
 
     def get_feedback(self, meas: Measurements) -> ObserverOutputs:
         """Get feedback signals."""
-        u_s_ab = self.pwm.get_realized_voltage()
+        u_c_ab = self.pwm.get_realized_voltage()
         if self.observer.sensorless:
-            fbk = self.observer.compute_output(meas, u_s_ab)
+            fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab)
         else:
-            fbk = self.observer.compute_output(meas, u_s_ab, meas.w_M)
+            fbk = self.observer.compute_output(
+                u_c_ab, meas.i_c_ab, meas.w_M, meas.theta_M
+            )
         fbk.u_dc = meas.u_dc
         return fbk
 
@@ -344,8 +346,8 @@ class ObserverBasedVHzController:
 
     def get_feedback(self, w_M_ref: float, meas: Measurements) -> ObserverOutputs:
         """Get feedback signals."""
-        u_s_ab = self.pwm.get_realized_voltage()
-        fbk = self.observer.compute_output(meas, u_s_ab, w_M_ref)
+        u_c_ab = self.pwm.get_realized_voltage()
+        fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab, w_M_ref)
         fbk.u_dc = meas.u_dc
         return fbk
 

--- a/motulator/drive/control/_sm_reference_gen.py
+++ b/motulator/drive/control/_sm_reference_gen.py
@@ -149,7 +149,7 @@ class ReferenceGenerator:
             psi_s = psi_s_ref * exp(1j * delta)
             i_s = complex(self.par.i_s_dq(psi_s))
             tau_M = 1.5 * self.par.n_p * (i_s * psi_s.conjugate()).imag
-            return tau_M_ref - tau_M
+            return abs(tau_M_ref) - tau_M
 
         if error(delta_range[0]) * error(delta_range[1]) >= 0:
             delta = 0.0

--- a/motulator/grid/control/_gfm_observer.py
+++ b/motulator/grid/control/_gfm_observer.py
@@ -155,7 +155,7 @@ class ObserverBasedGridFormingController:
         self,
         i_max: float,
         L: float,
-        R: float = 0,
+        R: float = 0.0,
         R_a: float | None = None,
         k_v: float | None = None,
         alpha_o: float = 2 * pi * 50,
@@ -187,9 +187,9 @@ class ObserverBasedGridFormingController:
         ref = References(T_s=self.T_s, p_g=p_g_ref, v_c=v_c_ref)
 
         # Complex gains for grid-forming mode
-        exp_j_theta = fbk.v_c / abs(fbk.v_c) if abs(fbk.v_c) > 0 else 1
+        exp_j_theta = fbk.v_c / abs(fbk.v_c) if abs(fbk.v_c) > 0.0 else 1.0
         k_p = exp_j_theta * self.R_a / (1.5 * ref.v_c)
-        k_v = exp_j_theta * (1 - 1j * self.k_v)
+        k_v = exp_j_theta * (1.0 - 1j * self.k_v)
 
         # Feedback correction for grid-forming mode
         e_c = k_p * (ref.p_g - fbk.p_g) + k_v * (ref.v_c - abs(fbk.v_c))
@@ -214,7 +214,7 @@ class ObserverBasedGridFormingController:
         """Post-process controller time series."""
         # Convert quantities to converter-output-voltage coordinates
         T = np.where(
-            np.abs(ts.fbk.v_c) > 0, np.conj(ts.fbk.v_c) / np.abs(ts.fbk.v_c), 1
+            np.abs(ts.fbk.v_c) > 0, np.conj(ts.fbk.v_c) / np.abs(ts.fbk.v_c), 1.0
         )
         ts.ref.u_c = T * ts.ref.u_c
         ts.fbk.i_c = T * ts.fbk.i_c

--- a/motulator/grid/control/_gfm_psc.py
+++ b/motulator/grid/control/_gfm_psc.py
@@ -120,8 +120,8 @@ class PowerSynchronizationController:
 
         # Voltage reference
         ref.u_c = ref.v_c + self.R_a * (ref.i_c - fbk.i_c) + self.R * fbk.i_c
-        u_c_ab_ref = exp(1j * fbk.theta_c) * ref.u_c
-        ref.d_abc = self.pwm(ref.T_s, u_c_ab_ref, fbk.u_dc, ref.w_c)
+        u_c_ref_ab = exp(1j * fbk.theta_c) * ref.u_c
+        ref.d_abc = self.pwm(ref.T_s, u_c_ref_ab, fbk.u_dc, ref.w_c)
 
         return ref
 


### PR DESCRIPTION
- Fix a bug in the current reference calculation. 
- Clarify the observer interfaces. 
- Clarify the drive control system interfaces. Now the AC-side converter current is measured by default, even if an output LC filter is used between the converter and the machine. This change does not affect existing public control methods.