### PR TITLE
Improvements for type checking and PLL interfaces

### DIFF
--- a/examples/drive/flux_vector/plot_flux_vector_ctrl_pmsyrm_thor_sat.py
+++ b/examples/drive/flux_vector/plot_flux_vector_ctrl_pmsyrm_thor_sat.py
@@ -52,7 +52,7 @@ utils.plot_flux_vs_current(fem_flux_map, base, lims=(-2, 2))
 
 # Create the current map interpolator directly from the FEM data
 points = np.column_stack(
-    (fem_flux_map.psi_s_dq.ravel().real, fem_flux_map.psi_s_dq.ravel().imag)
+    (np.real(fem_flux_map.psi_s_dq.ravel()), np.imag(fem_flux_map.psi_s_dq.ravel()))
 )
 mdl_curr_map = LinearNDInterpolator(points, fem_flux_map.i_s_dq.ravel())
 
@@ -60,7 +60,7 @@ mdl_curr_map = LinearNDInterpolator(points, fem_flux_map.i_s_dq.ravel())
 par = model.SaturatedSynchronousMachinePars(
     n_p=2,
     R_s=0.2,
-    i_s_dq_fcn=lambda psi_s_dq: mdl_curr_map((psi_s_dq.real, psi_s_dq.imag)),
+    i_s_dq_fcn=lambda psi_s_dq: mdl_curr_map((np.real(psi_s_dq), np.imag(psi_s_dq))),
 )
 machine = model.SynchronousMachine(par)
 k = 0.25 * nom.tau / base.w_M**2  # Quadratic load torque profile

--- a/motulator/grid/control/_gfm_observer.py
+++ b/motulator/grid/control/_gfm_observer.py
@@ -68,12 +68,12 @@ class Observer:
         self.w_g: float = w_nom
         self.state = ObserverStates(theta_c=0, u_gp=u_nom)
 
-    def compute_output(self, meas: Measurements, u_c_ab: complex) -> ObserverOutputs:
+    def compute_output(self, u_c_ab: complex, i_c_ab: complex) -> ObserverOutputs:
         """Compute the estimates."""
         out = ObserverOutputs(theta_c=self.state.theta_c)
 
         # Transform the measured values into synchronous coordinates
-        out.i_c = exp(-1j * out.theta_c) * meas.i_c_ab
+        out.i_c = exp(-1j * out.theta_c) * i_c_ab
         out.u_c = exp(-1j * out.theta_c) * u_c_ab
 
         # Estimates for the quasi-static converter voltage and the grid voltage
@@ -176,7 +176,7 @@ class ObserverBasedGridFormingController:
     def get_feedback(self, meas: Measurements) -> ObserverOutputs:
         """Get the feedback signals."""
         u_c_ab = self.pwm.get_realized_voltage()
-        fbk = self.observer.compute_output(meas, u_c_ab)
+        fbk = self.observer.compute_output(u_c_ab, meas.i_c_ab)
         fbk.u_dc = meas.u_dc
         return fbk
 


### PR DESCRIPTION
- Change how  the real and imaginary part are calculated for (complex |np.ndarray) to pass the static type checking of pyright 1.1.401 (latest). 
- Change the PLL/observer interfaces in grid converter controls to match the changes in PR #183 for drive controls.