### PR TITLE
Mechanical model speed observer for sensored synchronous machine drives

### DIFF
--- a/docs/source/control/drive/observers.md
+++ b/docs/source/control/drive/observers.md
@@ -335,13 +335,20 @@ where $\zeta_\infty$ is the desired damping ratio at high speeds. At zero speed,
 
 ### Speed Observer
 
-The speed observer is implemented in the {class}`motulator.drive.control.sm.SpeedObserver` class. The flux observer {eq}`sm_obs` is extended with the speed observer in the {class}`motulator.drive.control.sm.SpeedFluxObserver` class. The estimation error signal $\varepsilon$ for the mechanical rotor position is extracted as
+The speed observer is implemented in the {class}`motulator.drive.control.sm.SpeedObserver` class. The flux observer {eq}`sm_obs` is extended with the speed observer in the {class}`motulator.drive.control.sm.SpeedFluxObserver` class. The estimation error signal $\varepsilon$ for the mechanical rotor position is extracted as for sensorless
 
 ```{math}
 ---
-label: sm_obs_eps
+label: sm_obs_eps_sensorless
 ---
     \varepsilon = -\frac{1}{\np}\IM\left\{ \frac{\eo}{\hatpsiaux} \right\}
+```
+If mechanical angle is known, the estimation error signal is then
+```{math}
+---
+label: sm_obs_eps_sensored
+---
+    \varepsilon = \thetam - \hatthetam$
 ```
 
 Considering the rotor speed to be a quasi-constant disturbance, the speed can be estimated as {cite}`Hin2018`

--- a/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
+++ b/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
@@ -121,7 +121,7 @@ est_par = control.SaturatedSynchronousMachinePars(
 cfg = control.FluxVectorControllerCfg(
     i_s_max=2 * base.i, J=0.05, alpha_i=0, alpha_o=2 * np.pi * 8
 )
-vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=True)
+vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=False)
 speed_ctrl = control.SpeedController(J=0.05, alpha_s=2 * np.pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 
@@ -146,6 +146,7 @@ mdl.mechanics.set_external_load_torque(lambda t: (t > 1.25) * 0.7 * nom.tau)
 
 sim = model.Simulation(mdl, ctrl)
 res = sim.simulate(t_stop=2)
+# res = sim.simulate(t_stop=.2)
 utils.plot(res, base)
 
 # %%

--- a/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
+++ b/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
@@ -49,7 +49,7 @@ meas_flux_map = utils.MagneticModel(
 
 # Plot the measured data
 # sphinx_gallery_thumbnail_number = 4
-utils.plot_flux_vs_current(meas_flux_map, base, x_lims=(-1.5, 1.5))
+# utils.plot_flux_vs_current(meas_flux_map, base, x_lims=(-1.5, 1.5))
 
 # %%
 # Create a saturation model, which will be used in the control system.
@@ -82,22 +82,22 @@ est_current_map = est_current_map.as_magnetic_model(
 est_flux_map = est_current_map.invert()
 
 # Plot the saturation model (surface) and the measured data (points)
-utils.plot_map(
-    est_flux_map,
-    "d",
-    base,
-    lims={"x": (-2, 2), "y": (-2, 2), "z": (0, 1)},
-    ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
-    raw_data=meas_flux_map,
-)
-utils.plot_map(
-    est_flux_map,
-    "q",
-    base,
-    lims={"x": (-2, 2), "y": (-2, 2), "z": (-1.5, 1.5)},
-    ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
-    raw_data=meas_flux_map,
-)
+# utils.plot_map(
+#     est_flux_map,
+#     "d",
+#     base,
+#     lims={"x": (-2, 2), "y": (-2, 2), "z": (0, 1)},
+#     ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
+#     raw_data=meas_flux_map,
+# )
+# utils.plot_map(
+#     est_flux_map,
+#     "q",
+#     base,
+#     lims={"x": (-2, 2), "y": (-2, 2), "z": (-1.5, 1.5)},
+#     ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
+#     raw_data=meas_flux_map,
+# )
 
 # %%
 # Configure the system model.
@@ -128,12 +128,12 @@ ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 # %%
 # Visualize the control loci.
 
-i_s_vals = [1, 2, 3]  # Current values for the plots
-mc = utils.MachineCharacteristics(est_par)
-mc.plot_flux_vs_torque(i_s_vals, base)
-mc.plot_current_vs_torque(i_s_vals, base)
-mc.plot_current_loci(i_s_vals, base)
-mc.plot_flux_loci(i_s_vals, base)
+# i_s_vals = [1, 2, 3]  # Current values for the plots
+# mc = utils.MachineCharacteristics(est_par)
+# mc.plot_flux_vs_torque(i_s_vals, base)
+# mc.plot_current_vs_torque(i_s_vals, base)
+# mc.plot_current_loci(i_s_vals, base)
+# mc.plot_flux_loci(i_s_vals, base)
 
 # %%
 # Set the speed reference and the external load torque.
@@ -145,7 +145,7 @@ mdl.mechanics.set_external_load_torque(lambda t: (t > 1.25) * 0.7 * nom.tau)
 # Create the simulation object, simulate, and plot the results in per-unit values.
 
 sim = model.Simulation(mdl, ctrl)
-res = sim.simulate(t_stop=2)
+res = sim.simulate(t_stop=1.5)
 # res = sim.simulate(t_stop=.2)
 utils.plot(res, base)
 

--- a/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
+++ b/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
@@ -119,7 +119,7 @@ est_par = control.SaturatedSynchronousMachinePars(
     n_p=2, R_s=0.63, psi_s_dq_fcn=est_flux_map
 )
 cfg = control.FluxVectorControllerCfg(
-    i_s_max=2 * base.i, J=0.05, alpha_i=0, alpha_o=2 * np.pi * 8
+    i_s_max=2 * base.i, J=0.05, alpha_i=0, alpha_o=2 * np.pi * 8 
 )
 vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=False)
 speed_ctrl = control.SpeedController(J=0.05, alpha_s=2 * np.pi * 4)
@@ -145,8 +145,8 @@ mdl.mechanics.set_external_load_torque(lambda t: (t > 1.25) * 0.7 * nom.tau)
 # Create the simulation object, simulate, and plot the results in per-unit values.
 
 sim = model.Simulation(mdl, ctrl)
-res = sim.simulate(t_stop=1.5)
-# res = sim.simulate(t_stop=.2)
+# res = sim.simulate(t_stop=1.5)
+res = sim.simulate(t_stop=2)
 utils.plot(res, base)
 
 # %%

--- a/motulator/drive/control/_sm_flux_vector.py
+++ b/motulator/drive/control/_sm_flux_vector.py
@@ -234,14 +234,6 @@ class FluxVectorController:
         )
         assert cfg.alpha_o is not None
         self.observer = create_SpeedFluxObserver(par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J, sensorless)
-        # if sensorless:
-        #     self.observer = create_sensorless_observer(
-        #         par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J
-        #     )
-        # else:
-        #     self.observer = create_sensored_observer(
-        #         par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J
-        #     )
         self.sensorless = sensorless
         self.T_s = T_s
 

--- a/motulator/drive/control/_sm_flux_vector.py
+++ b/motulator/drive/control/_sm_flux_vector.py
@@ -9,6 +9,7 @@ from motulator.drive.control._sm_observers import (
     ObserverOutputs,
     create_sensored_observer,
     create_sensorless_observer,
+    create_SpeedFluxObserver,
     create_vhz_observer,
 )
 from motulator.drive.control._sm_reference_gen import ReferenceGenerator
@@ -232,14 +233,15 @@ class FluxVectorController:
             par, alpha_psi, cfg.alpha_tau, alpha_i
         )
         assert cfg.alpha_o is not None
-        if sensorless:
-            self.observer = create_sensorless_observer(
-                par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J
-            )
-        else:
-            self.observer = create_sensored_observer(
-                par, 2 * cfg.alpha_o, cfg.k_o, cfg.k_f
-            )
+        self.observer = create_SpeedFluxObserver(par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J, sensorless)
+        # if sensorless:
+        #     self.observer = create_sensorless_observer(
+        #         par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J
+        #     )
+        # else:
+        #     self.observer = create_sensored_observer(
+        #         par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J
+        #     )
         self.sensorless = sensorless
         self.T_s = T_s
 
@@ -251,7 +253,7 @@ class FluxVectorController:
         theta_M_meas: float | None,
     ) -> ObserverOutputs:
         """Get the feedback signals with motion sensors."""
-        return self.observer.compute_output(u_s_ab, i_s_ab, w_M_meas, theta_M_meas)
+        return self.observer.compute_output(u_s_ab, i_s_ab, theta_M_meas)
 
     def compute_output(self, tau_M_ref: float, fbk: ObserverOutputs) -> References:
         """Compute references."""

--- a/motulator/drive/control/_sm_flux_vector.py
+++ b/motulator/drive/control/_sm_flux_vector.py
@@ -9,7 +9,7 @@ from motulator.drive.control._sm_observers import (
     ObserverOutputs,
     create_sensored_observer,
     create_sensorless_observer,
-    create_SpeedFluxObserver,
+    create_speed_flux_observer,
     create_vhz_observer,
 )
 from motulator.drive.control._sm_reference_gen import ReferenceGenerator
@@ -233,7 +233,7 @@ class FluxVectorController:
             par, alpha_psi, cfg.alpha_tau, alpha_i
         )
         assert cfg.alpha_o is not None
-        self.observer = create_SpeedFluxObserver(par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J, sensorless)
+        self.observer = create_speed_flux_observer(par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J, sensorless)
         self.sensorless = sensorless
         self.T_s = T_s
 

--- a/motulator/drive/control/_sm_observers.py
+++ b/motulator/drive/control/_sm_observers.py
@@ -152,9 +152,6 @@ class FluxObserver:
             out.eps = err_elec / par.n_p
             out.eps_f = -ratio.real
 
-            # Angular speed of the coordinate system
-            out.w_c = out.w_m - self.k_theta * ratio.imag
-
         else:
             # Sensored mode assumes measured rotor angle, but speed is estimated
             err_elec = wrap(par.n_p * theta_M_meas - out.theta_m)
@@ -344,6 +341,7 @@ def create_sensorless_observer(
     k_f = (lambda w_m: 0) if k_f is None else k_f
 
     return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, True)
+
 def create_SpeedFluxObserver(
     par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
     alpha_o: float = 2 * pi * 100,

--- a/motulator/drive/control/_sm_observers.py
+++ b/motulator/drive/control/_sm_observers.py
@@ -135,8 +135,8 @@ class FluxObserver:
             out.theta_m = self.theta_m
 
         # Current and voltage vectors in (estimated) rotor coordinates
-        out.i_s = exp(-1j * out.theta_m) * i_s_ab
-        out.u_s = exp(-1j * out.theta_m) * u_s_ab
+        out.i_s = exp(-1j * out.theta_c) * i_s_ab
+        out.u_s = exp(-1j * out.theta_c) * u_s_ab
 
         # Auxiliary flux
         out.psi_a = complex(par.aux_flux(out.i_s))
@@ -351,8 +351,9 @@ def create_SpeedFluxObserver(
     sensorless: bool = True,
 ) -> SpeedFluxObserver:
     """
-    Create a sensorless flux observer with speed estimation. If rotor angle measurement is 
-    available, the observer estimates the speed based on the angle measurement, otherwise it is estimated based on the flux estimation error.
+    Create a flux observer with a speed estimation. If rotor angle measurement is 
+    available, the observer estimates the speed is based on the angle measurement, 
+    otherwise it is estimated based on the flux estimation error.
 
     Parameters
     ----------

--- a/motulator/drive/control/_sm_observers.py
+++ b/motulator/drive/control/_sm_observers.py
@@ -131,7 +131,8 @@ class FluxObserver:
         if self.sensorless or theta_M_meas is None:
             out.theta_c = out.theta_m = self.theta_m
         else:
-            out.theta_c = out.theta_m = par.n_p * theta_M_meas
+            out.theta_c = par.n_p * theta_M_meas
+            out.theta_m = self.theta_m
 
         # Current and voltage vectors in (estimated) rotor coordinates
         out.i_s = exp(-1j * out.theta_m) * i_s_ab
@@ -147,15 +148,21 @@ class FluxObserver:
         if self.sensorless:
             ratio = out.e_o / out.psi_a if out.psi_a != 0.0 else 0.0
             # Error signals for the mechanical rotor angle and PM flux estimation
-            out.eps = -ratio.imag / par.n_p
+            err_elec = -ratio.imag
+            out.eps = err_elec / par.n_p
             out.eps_f = -ratio.real
 
             # Angular speed of the coordinate system
             out.w_c = out.w_m - self.k_theta * ratio.imag
+
         else:
-            # Sensored mode assumes measured rotor coordinates
-            out.eps = out.eps_f = 0
-            out.w_c = out.w_m
+            # Sensored mode assumes measured rotor angle, but speed is estimated
+            err_elec = wrap(par.n_p * theta_M_meas - out.theta_m)
+            out.eps = err_elec / par.n_p
+            out.eps_f = 0
+        
+        # Angular speed of the coordinate system
+        out.w_c = out.w_m + self.k_theta * err_elec
 
         # Torque estimate
         out.tau_M = 1.5 * par.n_p * (out.i_s * out.psi_s.conjugate()).imag
@@ -204,6 +211,8 @@ class SpeedFluxObserver:
     J : float, optional
         Inertia of the mechanical system (kgm²). Defaults to None, which means the
         mechanical system model is not used.
+    sensorless : bool
+        If True, sensorless mode is used.
 
     """
 
@@ -214,6 +223,7 @@ class SpeedFluxObserver:
         k_o: Callable[[float], float],
         k_f: Callable[[float], float],
         J: float | None = None,
+        sensorless: bool=True,        
     ) -> None:
         # Configure observer gains for critically damped dynamics
         if J is None:
@@ -224,21 +234,21 @@ class SpeedFluxObserver:
             k_theta = 3 * alpha_o
             k_w = 3 * alpha_o**2
             k_tau = J * alpha_o**3
-
+            
         # Create component observers
         self.speed_observer = SpeedObserver(k_w, k_tau, J)
-        self.flux_observer = FluxObserver(par, k_theta, k_o, k_f, True)
+        self.flux_observer = FluxObserver(par, k_theta, k_o, k_f, sensorless)
 
     def compute_output(
         self,
         u_s_ab: complex,
         i_s_ab: complex,
-        w_M_meas: float | None = None,
+        # w_M_meas: float | None = None,
         theta_M_meas: float | None = None,
     ) -> ObserverOutputs:
         """Compute the feedback signals for the control system."""
         w_M, tau_L = self.speed_observer.compute_output()
-        out = self.flux_observer.compute_output(u_s_ab, i_s_ab, w_M)
+        out = self.flux_observer.compute_output(u_s_ab, i_s_ab, w_M, theta_M_meas)
         out.tau_L = tau_L
         return out
 
@@ -251,19 +261,20 @@ class SpeedFluxObserver:
 # %%
 def create_sensored_observer(
     par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
-    k_theta: float = 2 * pi * 200,
+    alpha_o: float = 2 * pi * 100,
     k_o: Callable[[float], float] | None = None,
     k_f: Callable[[float], float] | None = None,
-) -> FluxObserver:
+    J: float | None = None,
+) -> SpeedFluxObserver:
     """
-    Create a flux observer for a drive equipped with a motion sensor.
+    Create a sensored flux observer for a drive equipped with a rotor angle sensor.
 
     Parameters
     ----------
     par : SynchronousMachinePars | SaturatedSynchronousMachinePars
         Machine model parameters.
-    k_theta : float, optional
-        Rotor-angle estimation gain (rad/s), defaults to 2*pi*200.
+    alpha_o : float, optional
+        Speed estimation pole (rad/s), defaults to 2*pi*100.
     k_o : Callable[[float], float], optional
         Observer gain as a function of the rotor angular speed, defaults to ``lambda
         w_m: 0.25*(R_s*(L_d + L_q)/(L_d*L_q) + 0.2*abs(w_m))`` if `sensorless` else
@@ -273,17 +284,21 @@ def create_sensored_observer(
         to zero, ``lambda w_m: 0``. A typical nonzero gain is of the form ``lambda w_m:
         max(k*(abs(w_m) - w_min), 0)``, i.e., zero below the speed `w_min` (rad/s) and
         linearly increasing above that with the slope `k` (Vs).
+    J : float, optional
+        Inertia of the mechanical system (kgm²). Defaults to None, which means the
+        mechanical system model is not used.
 
     Returns
     -------
-    FluxObserver
-        Flux observer for a sensored drive.
+    SpeedFluxObserver
+        Sensorless flux observer with speed estimation.
 
     """
+
     k_o = (lambda w_m: 2 * pi * 15) if k_o is None else k_o
     k_f = (lambda w_m: 0) if k_f is None else k_f
 
-    return FluxObserver(par, k_theta, k_o, k_f, False)
+    return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, False)
 
 
 def create_sensorless_observer(
@@ -328,7 +343,58 @@ def create_sensorless_observer(
     k_o = (lambda w_m: sigma0 + 0.2 * abs(w_m)) if k_o is None else k_o
     k_f = (lambda w_m: 0) if k_f is None else k_f
 
-    return SpeedFluxObserver(par, alpha_o, k_o, k_f, J)
+    return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, True)
+def create_SpeedFluxObserver(
+    par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
+    alpha_o: float = 2 * pi * 100,
+    k_o: Callable[[float], float] | None = None,
+    k_f: Callable[[float], float] | None = None,
+    J: float | None = None,
+    sensorless: bool = True,
+) -> SpeedFluxObserver:
+    """
+    Create a sensorless flux observer with speed estimation. If rotor angle measurement is 
+    available, the observer estimates the speed based on the angle measurement, otherwise it is estimated based on the flux estimation error.
+
+    Parameters
+    ----------
+    par : SynchronousMachinePars | SaturatedSynchronousMachinePars
+        Machine model parameters.
+    alpha_o : float, optional
+        Speed estimation pole (rad/s), defaults to 2*pi*100.
+    k_o : Callable[[float], float], optional
+        Observer gain as a function of the rotor angular speed, defaults to ``lambda
+        w_m: 0.25*(R_s*(L_d + L_q)/(L_d*L_q) + 0.2*abs(w_m))`` if `sensorless` else
+        ``lambda w_m: 2*pi*15``.
+    k_f : Callable[[float], float], optional
+        PM-flux estimation gain (V) as a function of the rotor angular speed, defaults
+        to zero, ``lambda w_m: 0``. A typical nonzero gain is of the form ``lambda w_m:
+        max(k*(abs(w_m) - w_min), 0)``, i.e., zero below the speed `w_min` (rad/s) and
+        linearly increasing above that with the slope `k` (Vs).
+    J : float, optional
+        Inertia of the mechanical system (kgm²). Defaults to None, which means the
+        mechanical system model is not used.
+    sensorless : bool, default True
+        If True, sensorless mode is used, otherwise sensored mode is used.
+
+    Returns
+    -------
+    SpeedFluxObserver
+        Sensorless flux observer with speed estimation.
+
+    """
+    if sensorless:
+        # Poles at zero speed are located s = 0 and s = -2*sigma0
+        L_s0 = par.incr_ind_mat(0)
+        sigma0 = 0.25 * par.R_s * (1 / L_s0[0, 0] + 1 / L_s0[1, 1])
+
+        k_o = (lambda w_m: sigma0 + 0.2 * abs(w_m)) if k_o is None else k_o
+        k_f = (lambda w_m: 0) if k_f is None else k_f
+    else:
+        k_o = (lambda w_m: 2 * pi * 15) if k_o is None else k_o
+        k_f = (lambda w_m: 0) if k_f is None else k_f
+
+    return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, sensorless)
 
 
 def create_vhz_observer(

--- a/motulator/drive/control/_sm_observers.py
+++ b/motulator/drive/control/_sm_observers.py
@@ -342,7 +342,7 @@ def create_sensorless_observer(
 
     return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, True)
 
-def create_SpeedFluxObserver(
+def create_speed_flux_observer(
     par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
     alpha_o: float = 2 * pi * 100,
     k_o: Callable[[float], float] | None = None,


### PR DESCRIPTION
# Add mechanical model speed observer for sensorless synchronous machines

## Description
This PR introduces a mechanical model-based speed observer for synchronous machines in sensored operation. 

**Key changes:**
* Added a mechanical model speed observer for the sensored case, aligning the implementation with existing observer structures in the sensorless case
* Updated the related documentation. 

**Notes:**
* The documentation updates are still a work in progress and may not be in their final form yet. 