### PR TITLE
Unify sensored and sensorless observers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
 
   # Ruff formatter & linter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.15.21
     hooks:
     - id: ruff
       args: [--fix]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ copyright = "2026, Aalto Electric Drives"
 author = "Aalto Electric Drives"
 
 # The full version, including alpha/beta/rc tags
-release = "0.7.3"
+release = "0.7.4"
 
 # -- General configuration -------------------------------------------------------------
 
@@ -165,6 +165,7 @@ mathjax3_config = {
             "omegamo": "\\omega_\\mathrm{m0}",
             "tildeomegam": "\\tilde{\\omega}_\\mathrm{m}",
             "omegaM": "\\omega_\\mathrm{M}",
+            "omegaMmeas": "\\omega_\\mathrm{M}^\\mathrm{meas}",
             "omegaMref": "\\omega_\\mathrm{M}^\\mathrm{ref}",
             "omegamref": "\\omega_\\mathrm{m}^\\mathrm{ref}",
             "omegaL": "\\omega_\\mathrm{L}",
@@ -178,6 +179,7 @@ mathjax3_config = {
             "omegaro": "\\omega_\\mathrm{r0}",
             "thetam": "\\vartheta_\\mathrm{m}",
             "thetaM": "\\vartheta_\\mathrm{M}",
+            "thetaMmeas": "\\vartheta_\\mathrm{M}^\\mathrm{meas}",
             "thetaL": "\\vartheta_\\mathrm{L}",
             "thetaML": "\\vartheta_\\mathrm{ML}",
             "tauM": "\\tau_\\mathrm{M}",
@@ -242,6 +244,7 @@ mathjax3_config = {
             "hatabsug": "\\hat{u}_\\mathrm{g}",
             "hatug": "\\hat{\\mathbf{u}}_\\mathrm{g}",
             "ugs": "\\mathbf{u}_\\mathrm{g}^\\mathrm{s}",
+            "ugmeas": "\\mathbf{u}_\\mathrm{g}^\\mathrm{meas}",
             "ig": "\\mathbf{i}_\\mathrm{g}",
             "igs": "\\mathbf{i}_\\mathrm{g}^\\mathrm{s}",
             "eg": "\\mathbf{e}_\\mathrm{g}",
@@ -295,6 +298,7 @@ mathjax3_config = {
             # Estimates
             "hatomegam": "\\hat{\\omega}_\\mathrm{m}",
             "hatthetam": "\\hat{\\vartheta}_\\mathrm{m}",
+            "hatthetaM": "\\hat{\\vartheta}_\\mathrm{M}",
             "tildethetam": "\\tilde{\\vartheta}_\\mathrm{m}",
             "hatRs": "\\hat{R}_\\mathrm{s}",
             "hatRR": "\\hat{R}_\\mathrm{R}",

--- a/docs/source/control/drive/observers.md
+++ b/docs/source/control/drive/observers.md
@@ -1,6 +1,35 @@
 # Observers
 
-Observers estimate the internal state of electrical machines. In this document, we describe the observer design for induction and synchronous machines, including both sensored and sensorless designs. The observer designs allow to take the magnetic saturation into account.
+Observers estimate the internal state of electrical machines. We first present a generic rotor speed observer used in both induction and synchronous machine drives (both sensored and sensorless). Then, we describe the flux observer designs for induction and synchronous machines. These designs cover both sensored and sensorless drives and account for magnetic saturation.
+
+## Speed Observer
+
+The rotor speed observer described below is available in the {class}`motulator.drive.control.im.SpeedObserver` and {class}`motulator.drive.control.sm.SpeedObserver` classes for induction machines and synchronous machines, respectively.
+
+The rotor speed can be estimated (or filtered in sensored drives) using a disturbance observer structure {cite}`Fra1997`. The starting point is the mechanical model \[see {eq}`mech_stiff` in {doc}`/model/drive/mechanics`\], in which the load torque is considered as a quasi-constant disturbance. The resulting speed observer is
+
+```{math}
+---
+label: speed_obs
+---
+    \frac{\D \hatomegaM}{\D t} &= \frac{1}{\hat{J}}(\hattauM - \hattauL) + \koomega \varepsilon \\
+    \frac{\D\hattauL}{\D t} &= -\kotau\varepsilon
+```
+
+where $\hatomegaM$ is the estimated (or filtered in sensored drives) speed, $\hattauM$ is the electromagnetic torque estimate, $\hattauL$ is the load torque estimate, and $\koomega$ and $\kotau$ are the observer gains. The error signal $\varepsilon$ depends on the machine type and on whether the drive is sensored or sensorless, as described below. In induction machines, it is based on the speed estimation error; in synchronous machines, it is based on the position estimation error.
+
+As a special case, setting $\hat{J} = \infty$ and $\kotau = 0$ yields the commonly used reduced-order estimator {cite}`Har2001`
+
+```{math}
+---
+label: speed_obs_ro
+---
+    \frac{\D \hatomegaM}{\D t} = \koomega \varepsilon
+```
+
+which corresponds to a first-order low-pass filter of the true speed. The full-order observer {eq}`speed_obs` uses the mechanical model to avoid the lag inherent in such filtering. Clearly, the inertia estimate $\hat{J}$ can be safely overestimated.
+
+The observer structure {eq}`speed_obs` was originally proposed for sensored servo drives {cite}`Lor1991` and for signal-injection methods {cite}`Kim2003`. We use it also in model-based sensorless control, where the error signal comes from the flux observer instead of a measured speed or position.
 
 ## For Induction Machines
 
@@ -44,7 +73,7 @@ label: im_eo
     \eo = \hatLsgm\frac{\D \is}{\D t} - \us + \left(\hatRsgm + \jj\omegac\hatLsgm\right)\is - \left(\hatalpha - \jj\hatomegam\right)\hatpsiR
 ```
 
-where $\hatomegam$ is the rotor speed estimate. In sensored drives, the speed estimate is replaced with the measured speed, $\hatomegam = \omegam$. In observer-based V/Hz control {cite}`Tii2025b`, the speed estimate is replaced with the (rate-limited) speed reference, $\hatomegam = \omegamref$. Note that the derivative of the stator current in {eq}`im_eo` is integrated, i.e., the noise is not amplified. The torque estimate is given by
+where $\hatomegam = \np\hatomegaM$ represents the filtered rotor speed in sensored drives and estimated rotor speed in sensorless drives. In observer-based V/Hz control {cite}`Tii2025b`, the speed estimate is replaced with the (rate-limited) speed reference, $\hatomegam = \omegamref$. Note that the derivative of the stator current in {eq}`im_eo` is integrated, i.e., the noise is not amplified. The torque estimate is given by
 
 ```{math}
 ---
@@ -62,6 +91,8 @@ The angular speed $\omegac$ of the controller coordinate system can be arbitrari
 ```{note}
 Real-valued column vectors and the corresponding $2\times 2$ gain matrix were used in {cite}`Hin2010`. The complex form in {eq}`im_obs` has the same degrees of freedom.
 ```
+
+(im_obs_analysis)=
 
 #### Gain Analysis and Selection
 
@@ -87,7 +118,7 @@ Notice that the rotor flux estimation error is $\Delta\tildepsiR = \Delta\tildep
 
 ##### Sensored Drives
 
-In sensored drives, $\Delta\tildeomegam = 0$ holds and $\kob = 0$ is used. Under these assumptions, the estimation-error dynamics {eq}`tilde_psis` reduce to {cite}`Ver1988`
+In sensored drives, $\Delta\tildeomegam$ decoupled from the flux estimation. Consequently, this external disturbance can be omitted in the analysis, $\Delta\tildeomegam = 0$. Thus, the gain $\kob = 0$ can be used. Under these assumptions, the estimation-error dynamics {eq}`tilde_psis` reduce to {cite}`Ver1988`
 
 ```{math}
 ---
@@ -168,9 +199,26 @@ alt: Pole placement example in sensorless drives
 *Figure 1:* Example pole placement of the sensorless observer.
 ```
 
-### Speed Observer
+### Speed and Flux Observer
 
-The speed observer is implemented in the {class}`motulator.drive.control.im.SpeedObserver` class. The flux observer {eq}`im_obs` is extended with the speed observer in the {class}`motulator.drive.control.im.SpeedFluxObserver` class. The estimation error signal $\varepsilon$ for the mechanical rotor speed is extracted as
+To estimate the rotor speed, the flux observer {eq}`im_obs` is extended with the speed observer {eq}`speed_obs` in the {class}`motulator.drive.control.im.SpeedFluxObserver` class. The error signal is different in sensored and sensorless drives, as described below.
+
+#### Sensored Drives
+
+In sensored drives, the error signal for the mechanical rotor speed is
+
+```{math}
+---
+label: im_obs_eps_sensored
+---
+    \varepsilon = \omegaMmeas - \hatomegaM
+```
+
+where $\omegaMmeas$ is the measured speed and $\hatomegaM$ is the filtered speed. The measured speed $\omegaMmeas$ may contain a significant amount of noise (such as quantization noise from incremental encoders), which is filtered by the speed observer.
+
+#### Sensorless Drives
+
+In sensorless drives, the estimation error of the mechanical rotor speed is obtained from the flux observer {eq}`im_obs` and {eq}`im_eo` as
 
 ```{math}
 ---
@@ -179,43 +227,13 @@ label: im_obs_eps
     \varepsilon = -\frac{1}{\np}\IM\left\{ \frac{\eo}{\hatpsiR} \right\}
 ```
 
-Considering the rotor speed to be a quasi-constant disturbance, the speed can be estimated as {cite}`Har2001`
-
-```{math}
----
-label: im_speed_obs_ro
----
-    \frac{\D \hatomegaM}{\D t} = \koomega \varepsilon
-```
-
-where $\hatomegaM = \hatomegam/\np$ is the mechanical rotor speed estimate and $\koomega$ is the observer gain. This estimator is essentially the same as the conventional slip-relation-based estimator with the first-order low-pass filter {cite}`Hin2010`.
-
-To avoid the lag in the speed estimate, the speed can be estimated based on the mechanical model and considering the load torque as a quasi-constant disturbance (see {eq}`mech_stiff` in {doc}`/model/drive/mechanics`). This approach results in the speed observer
-
-```{math}
----
-label: im_speed_obs
----
-    \frac{\D \hatomegaM}{\D t} &= \frac{1}{\hat{J}}(\hattauM - \hattauL) + \koomega \varepsilon \\
-    \frac{\D\hattauL}{\D t} &= -\kotau\varepsilon
-```
-
-where $\hattauL$ is the load torque estimate and $\koomega$ and $\kotau$ are the observer gains. This observer is analogous to the speed observer in {cite}`Lor1991`. Note that setting $\hat{J} = \infty$ and $\kotau = 0$ yields the estimator {eq}`im_speed_obs_ro`; clearly, the inertia estimate $\hat{J}$ can be safely overestimated.
+The reduced-order speed observer {eq}`speed_obs_ro` with the error signal {eq}`im_obs_eps` is essentially the same as the conventional slip-relation-based estimator with the first-order low-pass filter, see {cite}`Hin2010`.
 
 #### Gain Analysis and Selection
 
-The flux observer gain {eq}`inherently` decouples the rotor speed estimation from the flux estimation. Therefore, the speed estimation dynamics can be analyzed separately. The estimator {eq}`im_speed_obs_ro` results in the first-order estimation dynamics
+The flux observer gain {eq}`inherently` decouples the rotor speed estimation from the flux estimation. Therefore, the speed estimation dynamics can be analyzed separately. Assuming an ideal measurement ($\omegaMmeas = \omegaM$) in the sensored case, the estimation dynamics are identical for both sensored and sensorless drives.
 
-```{math}
----
-label: im_speed_obs_ro_lin
----
-    \frac{\Delta\hatomegaM(s)}{\Delta\omegaM(s)} = \frac{\koomega}{s + \koomega}
-```
-
-The gain $\koomega = \alphao$ determines the speed-estimation bandwidth.
-
-For the observer {eq}`im_speed_obs`, the linearized estimation dynamics are
+For the observer {eq}`speed_obs`, the linearized estimation dynamics are
 
 ```{math}
 ---
@@ -225,6 +243,17 @@ label: im_speed_obs_lin
 ```
 
 where the stiff mechanical model is assumed in the derivation. The critically damped design is obtained by setting $\koomega = 2\alphao$ and $\kotau = \alphao^2 \hat{J}$, where $\alphao$ is the desired pole location.
+
+As a special case of {eq}`speed_obs`, setting $\hat{J} = \infty$ and $\kotau = 0$ yields {eq}`speed_obs_ro`. This reduced-order estimator gives the first-order estimation dynamics
+
+```{math}
+---
+label: im_speed_obs_ro_lin
+---
+    \frac{\Delta\hatomegaM(s)}{\Delta\omegaM(s)} = \frac{\koomega}{s + \koomega}
+```
+
+The gain $\koomega = \alphao$ determines the speed-estimation bandwidth.
 
 ## For Synchronous Machines
 
@@ -269,10 +298,10 @@ Based on {eq}`sm_model_obs`, a nonlinear state observer is formulated as
 label: sm_obs
 ---
     \frac{\D \hatpsis}{\D t} &= \us' - \hatRs\is' - \jj\omegac\hatpsis + \koa \eo + \kob \eo^* \\
-    \frac{\D\hatthetam}{\D t} &= \hatomegam - \kotheta \IM\left\{ \frac{\eo}{\psiaux} \right\} = \omegac
+    \frac{\D\hatthetam}{\D t} &= \hatomegam + \kotheta \np\varepsilon = \omegac
 ```
 
-where $\us'$ is the realized voltage estimate obtained from the PWM algorithm, $\omegac$ is the angular speed of the coordinate system, $\eo$ is the estimation error, $\koa$, $\kob$, and $\kotheta$ are observer gains, the estimates are marked with the hat, and $^*$ marks the complex conjugate. The flux estimation error is
+where $\us'$ is the realized voltage estimate obtained from the PWM algorithm, $\omegac$ is the angular speed of the coordinate system, and $\koa$, $\kob$, and $\kotheta$ are observer gains. Furthermore, $\hatomegam = \np \hatomegaM$ is the estimated rotor speed (in electrical rad/s) and $\varepsilon$ is the rotor position estimation error (in mechanical rad). The flux estimation error is
 
 ```{math}
 ---
@@ -281,7 +310,34 @@ label: sm_eo
     \eo = \hatpsisfcn(\is') - \hatpsis
 ```
 
-where $\hatpsisfcn$ is the flux map estimate. This observer structure is used in the {class}`motulator.drive.control.sm.FluxObserver` class. The implementation also contains optional PM-flux adaptation {cite}`Tuo2018`, see the {doc}`/drive_examples/current_vector/plot_2kw_ipmsm_cvc_adapt` example.
+where $\hatpsisfcn$ is the flux map estimate. In sensored drives, the estimation error signal is
+
+```{math}
+---
+label: sm_obs_eps_sensored
+---
+    \varepsilon = \thetaMmeas - \hatthetam/\np
+```
+
+where $\thetaMmeas$ is the measured mechanical angular position. In sensorless drives, the estimation error signal of the mechanical rotor position is obtained from {eq}`sm_obs` and {eq}`sm_eo` as {cite}`Hin2018`
+
+```{math}
+---
+label: sm_obs_eps_sensorless
+---
+    \varepsilon = -\frac{1}{\np}\IM\left\{ \frac{\eo}{\hatpsiaux} \right\}
+```
+
+The mechanical position is used in these signals for compatibility with the generic speed observer {eq}`speed_obs`. The torque estimate is given by
+
+```{math}
+---
+label: sm_obs_tauM
+---
+    \hattauM = \frac{3\np}{2}\IM\left\{\is' \hatpsis^* \right\}
+```
+
+This observer structure is used in the {class}`motulator.drive.control.sm.FluxObserver` class. The implementation also contains optional PM-flux adaptation {cite}`Tuo2018`, see the {doc}`/drive_examples/current_vector/plot_2kw_ipmsm_cvc_adapt` example.
 
 ```{note}
 Since the current is measured, the observer is fundamentally corrected by means of the current estimation error. However, due to the saliency and magnetic saturation, the current estimation error is convenient to map (or scale in the case of linear magnetics) to the flux linkage error.
@@ -293,9 +349,11 @@ Real-valued column vectors and the corresponding $2\times 2$ gain matrix were us
 
 #### Gain Analysis and Selection
 
+The analysis resembles that of induction machines, see {ref}`im_obs_analysis`. The following results can be derived from the linearized form of {eq}`sm_model_obs` -- {eq}`sm_obs_tauM`, see details in {cite}`Hin2018`.
+
 ##### Sensored Drives
 
-In sensored case, $\tildethetam = 0$ holds and $\kob = 0$ is used. Therefore, using {eq}`sm_model_obs` and {eq}`sm_obs`, the linearized estimation-error dynamics become
+In sensored case, the rotor position estimation error is decoupled from the flux estimation, i.e., it acts as an external disturbance in the flux estimation. Therefore, the gain $\kob = 0$ can be selected. Using {eq}`sm_model_obs` and {eq}`sm_obs`, the linearized estimation-error dynamics become
 
 ```{math}
 ---
@@ -310,9 +368,7 @@ where $\Delta$ marks the small-signal quantities, the subscript 0 marks the oper
 
 ##### Sensorless Drives
 
-The analysis of the sensorless case resembles that of induction machines, see {ref}`im_obs_sensorless`. The following results can be derived from the linearized form of {eq}`sm_model_obs` -- {eq}`sm_obs`, see details in {cite}`Hin2018`.
-
-To decouple the flux estimation from the rotor angle, the gains of {eq}`sm_obs` have to be of the form
+To decouple the flux estimation from the rotor angle, the gains of {eq}`sm_obs` have to be of the form {cite}`Hin2018`
 
 ```{math}
 ---
@@ -333,59 +389,15 @@ label: sigma_sensorless
 
 where $\zeta_\infty$ is the desired damping ratio at high speeds. At zero speed, one pole is placed at $s = 0$ and another at $s = -\beta$. Unstable double pole at $s = 0$ is avoided, enabling stable start of the machine.
 
-### Speed Observer
+### Speed and Flux Observer
 
-The speed observer is implemented in the {class}`motulator.drive.control.sm.SpeedObserver` class. The flux observer {eq}`sm_obs` is extended with the speed observer in the {class}`motulator.drive.control.sm.SpeedFluxObserver` class. The estimation error signal $\varepsilon$ for the mechanical rotor position is extracted as for sensorless
-
-```{math}
----
-label: sm_obs_eps_sensorless
----
-    \varepsilon = -\frac{1}{\np}\IM\left\{ \frac{\eo}{\hatpsiaux} \right\}
-```
-If mechanical angle is known, the estimation error signal is then
-```{math}
----
-label: sm_obs_eps_sensored
----
-    \varepsilon = \thetam - \hatthetam$
-```
-
-Considering the rotor speed to be a quasi-constant disturbance, the speed can be estimated as {cite}`Hin2018`
-
-```{math}
----
-label: sm_speed_obs_ro
----
-    \frac{\D \hatomegaM}{\D t} = \koomega \varepsilon
-```
-
-To avoid the lag in the speed estimate, the speed can be estimated based on the mechanical model and considering the load torque as a disturbance (see {eq}`mech_stiff` in {doc}`/model/drive/mechanics`). This approach results in the speed observer
-
-```{math}
----
-label: sm_speed_obs
----
-    \frac{\D \hatomegaM}{\D t} &= \frac{1}{\hat{J}}(\hattauM - \hattauL) + \koomega \varepsilon \\
-    \frac{\D\hattauL}{\D t} &= -\kotau \varepsilon
-```
-
-where $\hattauL$ is the load torque estimate and $\koomega$ and $\kotau$ are the observer gains. Note that setting $\hat{J} = \infty$ and $\kotau = 0$ yields the estimator {eq}`im_speed_obs_ro`; clearly, the inertia estimate $\hat{J}$ can be safely overestimated. Originally {eq}`sm_speed_obs` was used in servo drives with incremental encoders {cite}`Lor1991` and signal-injection methods {cite}`Kim2003`.
+To estimate the rotor speed and position, the flux observer {eq}`sm_obs` is extended with the speed observer {eq}`speed_obs` in the {class}`motulator.drive.control.sm.SpeedFluxObserver` class. The error signals are defined above in {eq}`sm_obs_eps_sensored` and {eq}`sm_obs_eps_sensorless` for sensored and sensorless drives, respectively.
 
 #### Gain Analysis and Selection
 
-The flux observer design decouples the speed and position estimation from the flux estimation. Therefore, the speed estimation dynamics can be analyzed separately. The estimator {eq}`sm_speed_obs_ro` results in the second-order estimation dynamics
+The flux observer design decouples the speed and position estimation from the flux estimation. Therefore, the speed estimation dynamics can be analyzed separately. Assuming an ideal measurement ($\thetaMmeas = \thetaM$) in the sensored case, the estimation dynamics are identical for both sensored and sensorless drives.
 
-```{math}
----
-label: sm_speed_obs_ro_lin
----
-    \frac{\Delta\hatomegaM(s)}{\Delta\omegaM(s)} = \frac{\alphao^2}{(s + \alphao)^2}
-```
-
-The critically damped design is obtained by setting $\kotheta = 2\alphao$ and $\koomega = \alphao^2$, where $\alphao$ is the desired pole location. The inertia estimate is avoided, but the lag limits achievable speed-control bandwidth {cite}`Tii2025a`.
-
-For the observer {eq}`sm_speed_obs`, the linearized estimation dynamics are
+For the observer {eq}`speed_obs`, the linearized estimation dynamics are
 
 ```{math}
 ---
@@ -396,3 +408,14 @@ label: sm_speed_obs_lin
 ```
 
 where the stiff mechanical model is assumed in the derivation. The critically damped design is obtained by setting $\kotheta = 3\alphao$, $\koomega = 3\alphao^2$, and $\kotau = \alphao^3 \hat{J}$.
+
+As a special case of {eq}`speed_obs`, setting $\hat{J} = \infty$ and $\kotau = 0$ yields {eq}`speed_obs_ro`. This reduced-order estimator gives the second-order estimation dynamics
+
+```{math}
+---
+label: sm_speed_obs_ro_lin
+---
+    \frac{\Delta\hatomegaM(s)}{\Delta\omegaM(s)} = \frac{\alphao^2}{(s + \alphao)^2}
+```
+
+The critically damped design is obtained by setting $\kotheta = 2\alphao$ and $\koomega = \alphao^2$, where $\alphao$ is the desired pole location. The inertia estimate is avoided, but the lag limits achievable speed-control bandwidth {cite}`Tii2025a`.

--- a/docs/source/control/grid/pll.md
+++ b/docs/source/control/grid/pll.md
@@ -10,7 +10,7 @@ Consider the positive-sequence voltage at the point of common coupling (PCC) in 
 ---
 label: disturbance
 ---
-\frac{\D\ug}{\D t} = \jj(\omegag - \omegac)\ug
+    \frac{\D\ug}{\D t} = \jj(\omegag - \omegac)\ug
 ```
 
 where $\omegag$ is the grid angular frequency. If needed, this disturbance model could be extended, e.g., with a negative-sequence component, allowing to design the PLL for unbalanced grids.
@@ -19,9 +19,9 @@ where $\omegag$ is the grid angular frequency. If needed, this disturbance model
 The disturbance model in {eq}`disturbance` can be equivalently expressed in polar form as
 
 \begin{align}
-\frac{\D \absug}{\D t} &= 0 \\
-\frac{\D \delta_\mathrm{g}}{\D t} &= \omegag - \omegac \\
-\ug &= \absug \e^{\jj\delta_\mathrm{g}}
+    \frac{\D \absug}{\D t} &= 0 \\
+    \frac{\D \delta_\mathrm{g}}{\D t} &= \omegag - \omegac \\
+    \ug &= \absug \e^{\jj\delta_\mathrm{g}}
 \end{align}
 
 where $\delta_\mathrm{g} = \thetag - \vartheta_\mathrm{c}$ is the angle of the grid voltage in general coordinates and the last equation is the output equation.
@@ -35,19 +35,19 @@ Based on {eq}`disturbance`, the disturbance observer containing the regular PLL 
 ---
 label: pll
 ---
-\frac{\D\hatug}{\D t} = \jj(\hatomegag - \omegac)\hatug + \alphao (\ug - \hatug )
+    \frac{\D\hatug}{\D t} = \jj(\hatomegag - \omegac)\hatug + \alphao (\ugmeas - \hatug )
 ```
 
-where $\hatug$ is the estimated PCC voltage, $\hatomegag$ is the grid angular frequency estimate (either constant corresponding to the nominal value or dynamic from grid-frequency tracking), and $\alphao$ is the bandwidth. If needed, the disturbance observer can be extended with the frequency tracking as
+where $\hatug$ is the estimated PCC voltage, $\ugmeas$ is the measured PCC voltage, $\hatomegag$ is the grid angular frequency estimate (either constant corresponding to the nominal value or dynamic from grid-frequency tracking), and $\alphao$ is the bandwidth. If needed, the disturbance observer can be extended with the frequency tracking as
 
 ```{math}
 ---
 label: frequency_tracking
 ---
-\frac{\D\hatomegag}{\D t} = k_\upomega\IM\left\{ \frac{\ug - \hatug}{\hatug} \right\}
+    \frac{\D\hatomegag}{\D t} = k_\upomega\IM\left\{ \frac{\ugmeas - \hatug}{\hatug} \right\}
 ```
 
-where $k_\upomega$ is the frequency-tracking gain. Notice that {eq}`pll` and {eq}`frequency_tracking` are both driven by the estimation error $\ug - \hatug$ of the PCC voltage.
+where $k_\upomega$ is the frequency-tracking gain. Notice that {eq}`pll` and {eq}`frequency_tracking` are both driven by the estimation error $\ugmeas - \hatug$ of the PCC voltage.
 
 ## PLL in Estimated PCC Voltage Coordinates
 
@@ -57,8 +57,8 @@ The disturbance observer {eq}`pll` can be equivalently expressed in estimated PC
 ---
 label: pll_polar
 ---
-\frac{\D\hatabsug}{\D t} &= \alphao \left(\mathrm{Re}\{\ug\} - \hatabsug \right) \\
-\frac{\D \hatthetag}{\D t} &= \hatomegag + \frac{\alphao}{\hatabsug}\IM\{ \ug \} = \omegac
+    \frac{\D\hatabsug}{\D t} &= \alphao \left(\mathrm{Re}\{\ugmeas\} - \hatabsug \right) \\
+    \frac{\D \hatthetag}{\D t} &= \hatomegag + \frac{\alphao}{\hatabsug}\IM\{ \ugmeas \} = \omegac
 ```
 
 It can be seen that the first equation in {eq}`pll_polar` is low-pass filtering of the measured PCC voltage magnitude and the second equation is the conventional angle-tracking PLL. In these coordinates, the frequency tracking {eq}`frequency_tracking` reduces to
@@ -67,21 +67,21 @@ It can be seen that the first equation in {eq}`pll_polar` is low-pass filtering 
 ---
 label: frequency_tracking_polar
 ---
-\frac{\D \hatomegag}{\D t} = \frac{k_\upomega}{\hatabsug } \IM\{ \ug \}
+    \frac{\D \hatomegag}{\D t} = \frac{k_\upomega}{\hatabsug } \IM\{ \ugmeas \}
 ```
 
 It can be noticed that the disturbance observer with the frequency tracking equals the conventional frequency-adaptive PLL {cite}`Kau1997`, with the additional feature of low-pass filtering the PCC voltage magnitude. The low-pass filtered PCC voltage can be used as a feedforward term in current control {cite}`Har2021`.
 
 ## Closed-Loop System Analysis
 
-The estimation-error dynamics are analyzed by means of linearization. Using the PCC voltage as an example, the small-signal deviation about the operating point is denoted by $\Delta \ug = \ug - \ugo$, where $\ugo$ is the operating-point quantity. From {eq}`disturbance`--{eq}`frequency_tracking`, the linearized model for the estimation-error dynamics is obtained as
+The estimation-error dynamics are analyzed by means of linearization, assuming $\ugmeas = \ug$. Using the PCC voltage as an example, the small-signal deviation about the operating point is denoted by $\Delta \ug = \ug - \ugo$, where $\ugo$ is the operating-point quantity. From {eq}`disturbance`--{eq}`frequency_tracking`, the linearized model for the estimation-error dynamics is obtained as
 
 ```{math}
 ---
 label: linearized_model
 ---
-\frac{\D\Delta \tildeug}{\D t} &= -\alphao\Delta \tildeug + \jj\ugo (\Delta \omegag - \Delta \hatomegag) \\
-\frac{\D\Delta \hatomegag}{\D t} &= k_\omega\IM\left\{ \frac{\Delta \tildeug}{\ugo} \right\}
+    \frac{\D\Delta \tildeug}{\D t} &= -\alphao\Delta \tildeug + \jj\ugo (\Delta \omegag - \Delta \hatomegag) \\
+    \frac{\D\Delta \hatomegag}{\D t} &= k_\omega\IM\left\{ \frac{\Delta \tildeug}{\ugo} \right\}
 ```
 
 where $\Delta \tildeug = \Delta\ug - \Delta \hatug$ is the estimation error.
@@ -92,7 +92,7 @@ First, assume that the grid frequency $\omegag$ is constant and the frequency tr
 ---
 label: closed_loop_pll
 ---
-\frac{\Delta\hatug(s)}{\Delta\ug(s)} = \frac{\alphao}{s + \alphao}
+    \frac{\Delta\hatug(s)}{\Delta\ug(s)} = \frac{\alphao}{s + \alphao}
 ```
 
 It can be realized that both the angle and magnitude of the PCC voltage estimate converge with the bandwidth $\alphao$.
@@ -103,7 +103,7 @@ Next, the frequency-tracking dynamics are also considered. From {eq}`linearized_
 ---
 label: closed_loop_pll_frequency_tracking
 ---
-\frac{\Delta\hatomegag(s)}{\Delta\omegag(s)} = \frac{k_\upomega}{s^2 + \alphao s + k_\omega}
+    \frac{\Delta\hatomegag(s)}{\Delta\omegag(s)} = \frac{k_\upomega}{s^2 + \alphao s + k_\omega}
 ```
 
 Choosing $k_\upomega = \alphapll^2$ and $\alphao = 2\alphapll$ yields the double pole at $s = -\alphapll$, where $\alphapll$ is the frequency-tracking bandwidth.

--- a/examples/drive/current_vector/plot_2kw_im_cvc_tq.py
+++ b/examples/drive/current_vector/plot_2kw_im_cvc_tq.py
@@ -37,8 +37,10 @@ mdl = model.Drive(machine, mechanics, converter)
 est_par = control.InductionMachineInvGammaPars(
     n_p=2, R_s=3.7, R_R=2.1, L_sgm=0.021, L_M=0.224
 )
-cfg = control.CurrentVectorControllerCfg(psi_s_nom=base.psi, i_s_max=1.5 * base.i)
-vector_ctrl = control.CurrentVectorController(est_par, cfg, sensorless=True)
+cfg = control.CurrentVectorControllerCfg(
+    psi_s_nom=base.psi, i_s_max=1.5 * base.i, sensorless=True
+)
+vector_ctrl = control.CurrentVectorController(est_par, cfg)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl=None)
 
 # %%

--- a/examples/drive/current_vector/plot_2kw_im_sat_cvc.py
+++ b/examples/drive/current_vector/plot_2kw_im_sat_cvc.py
@@ -51,8 +51,10 @@ est_par = control.InductionMachineInvGammaPars(
     n_p=2, R_s=3.7, R_R=2.1, L_sgm=0.021, L_M=0.224
 )
 # est_par = par  # Uncomment this line to use the perfectly known machine model
-cfg = control.CurrentVectorControllerCfg(psi_s_nom=base.psi, i_s_max=1.5 * base.i)
-vector_ctrl = control.CurrentVectorController(est_par, cfg, sensorless=True)
+cfg = control.CurrentVectorControllerCfg(
+    psi_s_nom=base.psi, i_s_max=1.5 * base.i, sensorless=True
+)
+vector_ctrl = control.CurrentVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=0.015, alpha_s=2 * pi * 4)
 # speed_ctrl = control.PIController(k_p=1, k_i=1)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)

--- a/examples/drive/current_vector/plot_2kw_ipmsm_diode_cvc.py
+++ b/examples/drive/current_vector/plot_2kw_ipmsm_diode_cvc.py
@@ -33,8 +33,10 @@ mdl = model.Drive(machine, mechanics, converter, pwm=True)
 # Configure the control system.
 
 est_par = par  # Assume accurate model parameter estimates
-cfg = control.CurrentVectorControllerCfg(i_s_max=1.5 * base.i, alpha_o=2 * pi * 100)
-vector_ctrl = control.CurrentVectorController(est_par, cfg, T_s=250e-6)
+cfg = control.CurrentVectorControllerCfg(
+    i_s_max=1.5 * base.i, alpha_o=2 * pi * 100, T_s=250e-6
+)
+vector_ctrl = control.CurrentVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=0.015, alpha_s=2 * pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 

--- a/examples/drive/current_vector/plot_5kw_pmsyrm_thor_sat_cvc.py
+++ b/examples/drive/current_vector/plot_5kw_pmsyrm_thor_sat_cvc.py
@@ -59,8 +59,10 @@ mdl = model.Drive(machine, mechanics, converter)
 est_par = control.SaturatedSynchronousMachinePars(
     n_p=2, R_s=0.2, psi_s_dq_fcn=fem_flux_map, i_s_dq_fcn=fem_curr_map
 )
-cfg = control.CurrentVectorControllerCfg(i_s_max=2 * base.i, J=2 * 0.0042)
-vector_ctrl = control.CurrentVectorController(est_par, cfg, sensorless=True)
+cfg = control.CurrentVectorControllerCfg(
+    i_s_max=2 * base.i, J=2 * 0.0042, sensorless=True
+)
+vector_ctrl = control.CurrentVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=2 * 0.0042, alpha_s=2 * pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 

--- a/examples/drive/flux_vector/plot_2kw_im_sat_fvc.py
+++ b/examples/drive/flux_vector/plot_2kw_im_sat_fvc.py
@@ -46,8 +46,9 @@ cfg = control.FluxVectorControllerCfg(
     i_s_max=1.5 * base.i,
     J=0.015,  # Inertia estimate enables the speed observer
     alpha_i=0,  # Integral action is not necessary with the speed observer
+    sensorless=True,
 )
-vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=True)
+vector_ctrl = control.FluxVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=0.015, alpha_s=2 * pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 

--- a/examples/drive/flux_vector/plot_2kw_ipmsm_fvc.py
+++ b/examples/drive/flux_vector/plot_2kw_ipmsm_fvc.py
@@ -32,8 +32,8 @@ mdl = model.Drive(machine, mechanics, converter)
 # Configure the control system.
 
 est_par = par  # Assume accurate model parameter estimates
-cfg = control.FluxVectorControllerCfg(i_s_max=1.5 * base.i)
-vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=True)
+cfg = control.FluxVectorControllerCfg(i_s_max=1.5 * base.i, sensorless=True)
+vector_ctrl = control.FluxVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=0.015, alpha_s=2 * pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 

--- a/examples/drive/flux_vector/plot_5kw_pmsyrm_thor_sat_fvc.py
+++ b/examples/drive/flux_vector/plot_5kw_pmsyrm_thor_sat_fvc.py
@@ -81,8 +81,10 @@ est_par = control.SaturatedSynchronousMachinePars(
     n_p=2, R_s=0.2, psi_s_dq_fcn=fem_flux_map
 )
 # Since the inertia `J` is provided, the mechanical-model-based speed observer is used
-cfg = control.FluxVectorControllerCfg(i_s_max=2 * base.i, J=2 * 0.0042, alpha_i=0)
-vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=True)
+cfg = control.FluxVectorControllerCfg(
+    i_s_max=2 * base.i, J=2 * 0.0042, alpha_i=0, sensorless=True
+)
+vector_ctrl = control.FluxVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=2 * 0.0042, alpha_s=2 * np.pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 

--- a/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
+++ b/examples/drive/flux_vector/plot_6kw_pmsyrm_sat_fvc.py
@@ -49,7 +49,7 @@ meas_flux_map = utils.MagneticModel(
 
 # Plot the measured data
 # sphinx_gallery_thumbnail_number = 4
-# utils.plot_flux_vs_current(meas_flux_map, base, x_lims=(-1.5, 1.5))
+utils.plot_flux_vs_current(meas_flux_map, base, x_lims=(-1.5, 1.5))
 
 # %%
 # Create a saturation model, which will be used in the control system.
@@ -82,22 +82,22 @@ est_current_map = est_current_map.as_magnetic_model(
 est_flux_map = est_current_map.invert()
 
 # Plot the saturation model (surface) and the measured data (points)
-# utils.plot_map(
-#     est_flux_map,
-#     "d",
-#     base,
-#     lims={"x": (-2, 2), "y": (-2, 2), "z": (0, 1)},
-#     ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
-#     raw_data=meas_flux_map,
-# )
-# utils.plot_map(
-#     est_flux_map,
-#     "q",
-#     base,
-#     lims={"x": (-2, 2), "y": (-2, 2), "z": (-1.5, 1.5)},
-#     ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
-#     raw_data=meas_flux_map,
-# )
+utils.plot_map(
+    est_flux_map,
+    "d",
+    base,
+    lims={"x": (-2, 2), "y": (-2, 2), "z": (0, 1)},
+    ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
+    raw_data=meas_flux_map,
+)
+utils.plot_map(
+    est_flux_map,
+    "q",
+    base,
+    lims={"x": (-2, 2), "y": (-2, 2), "z": (-1.5, 1.5)},
+    ticks={"x": [-2, -1, 0, 1, 2], "y": [-2, -1, 0, 1, 2]},
+    raw_data=meas_flux_map,
+)
 
 # %%
 # Configure the system model.
@@ -119,21 +119,21 @@ est_par = control.SaturatedSynchronousMachinePars(
     n_p=2, R_s=0.63, psi_s_dq_fcn=est_flux_map
 )
 cfg = control.FluxVectorControllerCfg(
-    i_s_max=2 * base.i, J=0.05, alpha_i=0, alpha_o=2 * np.pi * 8 
+    i_s_max=2 * base.i, J=0.05, alpha_i=0, alpha_o=2 * np.pi * 8, sensorless=True
 )
-vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=False)
+vector_ctrl = control.FluxVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=0.05, alpha_s=2 * np.pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 
 # %%
 # Visualize the control loci.
 
-# i_s_vals = [1, 2, 3]  # Current values for the plots
-# mc = utils.MachineCharacteristics(est_par)
-# mc.plot_flux_vs_torque(i_s_vals, base)
-# mc.plot_current_vs_torque(i_s_vals, base)
-# mc.plot_current_loci(i_s_vals, base)
-# mc.plot_flux_loci(i_s_vals, base)
+i_s_vals = [1, 2, 3]  # Current values for the plots
+mc = utils.MachineCharacteristics(est_par)
+mc.plot_flux_vs_torque(i_s_vals, base)
+mc.plot_current_vs_torque(i_s_vals, base)
+mc.plot_current_loci(i_s_vals, base)
+mc.plot_flux_loci(i_s_vals, base)
 
 # %%
 # Set the speed reference and the external load torque.
@@ -145,7 +145,6 @@ mdl.mechanics.set_external_load_torque(lambda t: (t > 1.25) * 0.7 * nom.tau)
 # Create the simulation object, simulate, and plot the results in per-unit values.
 
 sim = model.Simulation(mdl, ctrl)
-# res = sim.simulate(t_stop=1.5)
 res = sim.simulate(t_stop=2)
 utils.plot(res, base)
 

--- a/examples/drive/flux_vector/plot_7kw_syrm_sat_fvc.py
+++ b/examples/drive/flux_vector/plot_7kw_syrm_sat_fvc.py
@@ -49,8 +49,10 @@ est_par = control.SaturatedSynchronousMachinePars(
 )
 
 # Configure the controller
-cfg = control.FluxVectorControllerCfg(i_s_max=2 * base.i, psi_s_min=0.5 * base.psi)
-vector_ctrl = control.FluxVectorController(est_par, cfg, sensorless=True)
+cfg = control.FluxVectorControllerCfg(
+    i_s_max=2 * base.i, psi_s_min=0.5 * base.psi, sensorless=True
+)
+vector_ctrl = control.FluxVectorController(est_par, cfg)
 speed_ctrl = control.SpeedController(J=0.015, alpha_s=2 * np.pi * 4)
 ctrl = control.VectorControlSystem(vector_ctrl, speed_ctrl)
 

--- a/examples/grid/grid_following/plot_10kva_dc_bus_gfl.py
+++ b/examples/grid/grid_following/plot_10kva_dc_bus_gfl.py
@@ -31,10 +31,11 @@ mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 # %%
 # Configure the control system.
 
+cfg = control.CurrentVectorControllerCfg(i_max=1.5 * base.i, L=0.2 * base.L)
+inner_ctrl = control.CurrentVectorController(cfg)
 dc_bus_voltage_ctrl = control.DCBusVoltageController(
     C_dc=1e-3, alpha_dc=2 * np.pi * 30, p_max=base.p
 )
-inner_ctrl = control.CurrentVectorController(i_max=1.5 * base.i, L=0.2 * base.L)
 ctrl = control.GridConverterControlSystem(inner_ctrl, dc_bus_voltage_ctrl)
 
 # %%

--- a/examples/grid/grid_following/plot_10kva_gfl.py
+++ b/examples/grid/grid_following/plot_10kva_gfl.py
@@ -29,7 +29,8 @@ mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 # %%
 # Configure the control system.
 
-inner_ctrl = control.CurrentVectorController(i_max=1.5 * base.i, L=0.2 * base.L)
+cfg = control.CurrentVectorControllerCfg(i_max=1.5 * base.i, L=0.2 * base.L)
+inner_ctrl = control.CurrentVectorController(cfg)
 ctrl = control.GridConverterControlSystem(inner_ctrl)
 
 # %%

--- a/examples/grid/grid_following/plot_10kva_lcl_gfl.py
+++ b/examples/grid/grid_following/plot_10kva_lcl_gfl.py
@@ -31,9 +31,10 @@ mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 # %%
 # Configure the control system.
 
-inner_ctrl = control.CurrentVectorController(
+cfg = control.CurrentVectorControllerCfg(
     i_max=1.5 * base.i, L=0.073 * base.L, T_s=100e-6
 )
+inner_ctrl = control.CurrentVectorController(cfg)
 ctrl = control.GridConverterControlSystem(inner_ctrl)
 
 

--- a/examples/grid/grid_forming/plot_13kva_do_gfm.py
+++ b/examples/grid/grid_forming/plot_13kva_do_gfm.py
@@ -29,7 +29,7 @@ mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 # %%
 # Configure the control system.
 
-inner_ctrl = control.ObserverBasedGridFormingController(
+cfg = control.ObserverBasedGridFormingControllerCfg(
     i_max=1.3 * base.i,
     L=0.35 * base.L,
     R=0.05 * base.Z,
@@ -37,6 +37,7 @@ inner_ctrl = control.ObserverBasedGridFormingController(
     u_nom=base.u,
     w_nom=base.w,
 )
+inner_ctrl = control.ObserverBasedGridFormingController(cfg)
 ctrl = control.GridConverterControlSystem(inner_ctrl)
 
 # %%

--- a/examples/grid/grid_forming/plot_13kva_rfpsc_gfm.py
+++ b/examples/grid/grid_forming/plot_13kva_rfpsc_gfm.py
@@ -28,9 +28,10 @@ mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 # Configure the control system.
 
 # Control configuration parameters
-inner_ctrl = control.PowerSynchronizationController(
+cfg = control.PowerSynchronizationControllerCfg(
     u_nom=base.u, w_nom=base.w, i_max=1.3 * base.i, R=0.05 * base.Z, R_a=0.2 * base.Z
 )
+inner_ctrl = control.PowerSynchronizationController(cfg)
 ctrl = control.GridConverterControlSystem(inner_ctrl)
 
 # %%

--- a/examples/grid/identification/plot_10kva_gfl_identification.py
+++ b/examples/grid/identification/plot_10kva_gfl_identification.py
@@ -41,9 +41,10 @@ mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 # %%
 # Configure the control system.
 
-inner_ctrl = control.CurrentVectorController(
+cfg = control.CurrentVectorControllerCfg(
     i_max=1.5 * base.i, L=0.2 * base.L, T_s=identification_cfg.T_s
 )
+inner_ctrl = control.CurrentVectorController(cfg)
 ctrl = control.GridConverterControlSystem(inner_ctrl)
 
 # Set the references

--- a/examples/grid/identification/plot_13kva_do_gfm_identification.py
+++ b/examples/grid/identification/plot_13kva_do_gfm_identification.py
@@ -41,7 +41,7 @@ mdl = model.GridConverterSystem(converter, ac_filter, ac_source)
 # %%
 # Configure the control system.
 
-inner_ctrl = control.ObserverBasedGridFormingController(
+cfg = control.ObserverBasedGridFormingControllerCfg(
     i_max=1.3 * base.i,
     L=0.35 * base.L,
     R=0.05 * base.Z,
@@ -50,6 +50,7 @@ inner_ctrl = control.ObserverBasedGridFormingController(
     w_nom=base.w,
     T_s=identification_cfg.T_s,
 )
+inner_ctrl = control.ObserverBasedGridFormingController(cfg)
 ctrl = control.GridConverterControlSystem(inner_ctrl)
 
 ctrl.set_power_ref(0.5 * base.p)

--- a/motulator/drive/control/_im_current_vector.py
+++ b/motulator/drive/control/_im_current_vector.py
@@ -3,7 +3,7 @@
 from cmath import exp, phase
 from dataclasses import dataclass
 from math import pi, sqrt
-from typing import Callable
+from typing import Callable, cast
 
 import numpy as np
 
@@ -12,8 +12,7 @@ from motulator.common.control._base import TimeSeries
 from motulator.common.utils._utils import clip
 from motulator.drive.control._im_observers import (
     ObserverOutputs,
-    create_sensored_observer,
-    create_sensorless_observer,
+    create_speed_flux_observer,
 )
 from motulator.drive.utils._parameters import (
     InductionMachineInvGammaPars,
@@ -216,9 +215,13 @@ class CurrentVectorControllerCfg:
         Voltage utilization factor, defaults to 0.95.
     k_fw : float, optional
         Field-weakening gain (1/H), defaults to `2*R_R/(w_s_nom*L_sgm**2)`.
-    J : float, optional
+    J : float | None, optional
         Inertia (kgm²). Defaults to None, meaning the mechanical system model is not
         used in speed estimation.
+    sensorless : bool, optional
+        If True, sensorless control is used, defaults to True.
+    T_s : float, optional
+        Sampling period (s), defaults to 125e-6.
 
     """
 
@@ -232,6 +235,8 @@ class CurrentVectorControllerCfg:
     k_u: float = 0.95
     k_fw: float = 0.0
     J: float | None = None
+    sensorless: bool = True
+    T_s: float = 125e-6
 
     def __post_init__(self) -> None:
         """Set alpha_o default based on J value."""
@@ -251,10 +256,6 @@ class CurrentVectorController:
         Machine model parameters.
     cfg : CurrentVectorControllerCfg
         Current-vector controller configuration.
-    sensorless : bool, optional
-        If True, sensorless control is used, defaults to True.
-    T_s : float, optional
-        Sampling period (s), defaults to 125e-6.
 
     """
 
@@ -262,20 +263,17 @@ class CurrentVectorController:
         self,
         par: InductionMachineInvGammaPars | InductionMachinePars,
         cfg: CurrentVectorControllerCfg,
-        sensorless: bool = True,
-        T_s: float = 125e-6,
     ) -> None:
+        self.cfg = cfg
+        self.sensorless = cfg.sensorless
         self.reference_gen = CurrentReferenceGenerator(
             par, cfg.psi_s_nom, cfg.i_s_max, cfg.w_s_nom, cfg.k_u, cfg.k_fw
         )
         self.current_ctrl = CurrentController(par, cfg.alpha_c, cfg.alpha_i)
-        if sensorless:
-            assert cfg.alpha_o is not None
-            self.observer = create_sensorless_observer(par, cfg.alpha_o, cfg.k_o, cfg.J)
-        else:
-            self.observer = create_sensored_observer(par, cfg.k_o)
-        self.sensorless = sensorless
-        self.T_s = T_s
+        self.observer = create_speed_flux_observer(
+            par, cast(float, cfg.alpha_o), cfg.k_o, cfg.sensorless, cfg.J
+        )
+        self.T_s = cfg.T_s
 
     def get_feedback(
         self,

--- a/motulator/drive/control/_im_flux_vector.py
+++ b/motulator/drive/control/_im_flux_vector.py
@@ -10,8 +10,7 @@ from motulator.common.control._base import TimeSeries
 from motulator.common.utils._utils import sign
 from motulator.drive.control._im_observers import (
     ObserverOutputs,
-    create_sensored_observer,
-    create_sensorless_observer,
+    create_speed_flux_observer,
     create_vhz_observer,
 )
 from motulator.drive.utils._parameters import (
@@ -238,8 +237,8 @@ class FluxVectorControllerCfg:
     alpha_i : float, optional
         Integral action bandwidth (rad/s), defaults to `alpha_tau`.
     alpha_o : float, optional
-        Speed estimation poles (rad/s). Defaults to 2*pi*60 if `J` is None, otherwise
-        2*pi*30, keeping the default speed observer gain the same.
+        Speed estimation poles (rad/s). If `None`, the default depends on the operation
+        mode and the inertia `J`.
     k_o : Callable[[float], complex], optional
         Observer gain as a function of the rotor angular speed.
     alpha_c : float, optional
@@ -253,6 +252,10 @@ class FluxVectorControllerCfg:
     J : float, optional
         Inertia (kgm²). Defaults to None, meaning the mechanical system model is not
         used in speed estimation.
+    sensorless : bool, optional
+        If True, sensorless control is used, defaults to True.
+    T_s : float, optional
+        Sampling period (s), defaults to 125e-6.
 
     """
 
@@ -268,12 +271,15 @@ class FluxVectorControllerCfg:
     k_u: float = 0.9
     k_b: float = 0.9
     J: float | None = None
+    sensorless: bool = True
+    T_s: float = 125e-6
 
     def __post_init__(self) -> None:
-        """Set alpha_o default based on J value."""
+        """Set alpha_o default based on J value and operation mode."""
         if self.alpha_o is None:
-            # To keep the speed observer gain k_w the same
-            alpha = 2 * pi * 60
+            # Note: If J is not given, alpha_o is halved to keep the default speed
+            # observer gain k_w the same.
+            alpha = 2 * pi * 60 if self.sensorless else 2 * pi * 400
             self.alpha_o = alpha if self.J is None else 0.5 * alpha
 
 
@@ -291,10 +297,6 @@ class FluxVectorController:
         Machine model parameters.
     cfg : FluxVectorControllerCfg
         Flux-vector control configuration.
-    sensorless : bool, optional
-        If True, sensorless control is used, defaults to True.
-    T_s : float, optional
-        Sampling period (s), defaults to 125e-6.
 
     References
     ----------
@@ -308,8 +310,6 @@ class FluxVectorController:
         self,
         par: InductionMachineInvGammaPars | InductionMachinePars,
         cfg: FluxVectorControllerCfg,
-        sensorless: bool = True,
-        T_s: float = 125e-6,
     ) -> None:
         self.reference_gen = ReferenceGenerator(
             par, cfg.psi_s_nom, cfg.i_s_max, cfg.tau_M_max, cfg.k_u, cfg.k_b
@@ -319,13 +319,11 @@ class FluxVectorController:
         self.flux_torque_ctrl = FluxTorqueController(
             par, alpha_psi, cfg.alpha_tau, alpha_i, cfg.alpha_c, cfg.i_s_max
         )
-        if sensorless:
-            assert cfg.alpha_o is not None
-            self.observer = create_sensorless_observer(par, cfg.alpha_o, cfg.k_o, cfg.J)
-        else:
-            self.observer = create_sensored_observer(par, cfg.k_o)
-        self.sensorless = sensorless
-        self.T_s = T_s
+        self.observer = create_speed_flux_observer(
+            par, cfg.alpha_o, cfg.k_o, cfg.sensorless, cfg.J
+        )
+        self.sensorless = cfg.sensorless
+        self.T_s = cfg.T_s
 
     def get_feedback(
         self,
@@ -386,6 +384,8 @@ class ObserverBasedVHzControllerCfg:
         Voltage utilization factor, defaults to 0.9.
     k_b : float, optional
         Breakdown torque margin, defaults to 0.9.
+    T_s : float, optional
+        Sampling period (s), defaults to 250e-6.
 
     """
 
@@ -397,6 +397,7 @@ class ObserverBasedVHzControllerCfg:
     k_o: Callable[[float], complex] | None = None
     k_u: float = 0.9
     k_b: float = 0.9
+    T_s: float = 250e-6
 
 
 class ObserverBasedVHzController:
@@ -412,8 +413,6 @@ class ObserverBasedVHzController:
         Machine model parameters.
     cfg : ObserverBasedVHzControllerCfg
         Observer-based V/Hz controller configuration.
-    T_s : float, optional
-        Sampling period (s), defaults to 250e-6.
 
     """
 
@@ -421,8 +420,8 @@ class ObserverBasedVHzController:
         self,
         par: InductionMachineInvGammaPars | InductionMachinePars,
         cfg: ObserverBasedVHzControllerCfg,
-        T_s: float = 250e-6,
     ) -> None:
+        self.cfg = cfg
         self.pwm_mode: Literal["MPE", "MME", "six_step"] = "MME"
         self.reference_gen = ReferenceGenerator(
             par, cfg.psi_s_nom, cfg.i_s_max, inf, cfg.k_u, cfg.k_b
@@ -433,7 +432,7 @@ class ObserverBasedVHzController:
         self.observer = create_vhz_observer(par, cfg.k_o)
         self.alpha_f: float = cfg.alpha_f
         self.tau_M_lpf: float = 0.0  # Low-pass-filtered torque estimate
-        self.T_s = T_s
+        self.T_s = cfg.T_s
         # Configurations for pure open-loop V/Hz control
         if par.L_M == inf:
             self.observer.psi_s = cfg.psi_s_nom

--- a/motulator/drive/control/_im_observers.py
+++ b/motulator/drive/control/_im_observers.py
@@ -84,7 +84,7 @@ class FluxObserver:
         self._old_i_s: complex = 0j
 
     def compute_output(
-        self, u_s_ab: complex, i_s_ab: complex, w_M: float | None
+        self, u_s_ab: complex, i_s_ab: complex, w_M: float
     ) -> ObserverOutputs:
         """
         Compute the feedback signals for the control system.
@@ -95,8 +95,8 @@ class FluxObserver:
             Stator voltage (V) in stator coordinates.
         i_s_ab : complex
             Stator current (A) in stator coordinates.
-        w_M : float, optional
-            Rotor speed (mechanical rad/s), either measured or estimated.
+        w_M : float
+            Rotor speed (mechanical rad/s), typically from the speed observer.
 
         Returns
         -------
@@ -115,8 +115,6 @@ class FluxObserver:
         out.u_s = exp(-1j * out.theta_c) * u_s_ab
 
         # Mechanical and electrical angular speeds of the rotor
-        if w_M is None:
-            raise ValueError("Either measured or estimated speed must be provided")
         out.w_M = w_M
         out.w_m = par.n_p * w_M
 
@@ -181,16 +179,19 @@ class SpeedFluxObserver:
 
     This class implements a reduced-order flux observer for induction machines with
     speed estimation. If the inertia of the mechanical system is provided, the observer
-    also estimates the load torque, to avoid the lag in the speed estimate.
+    also estimates the load torque, to avoid the lag in the speed estimate. In sensored
+    mode, the measured rotor speed is filtered.
 
     Parameters
     ----------
     par : InductionMachineInvGammaPars | InductionMachinePars
         Machine model parameters.
-    k_o1, k_o2 : Callable[[float], complex]
-        Observer gains as functions of the electrical angular speed of the rotor.
     alpha_o : float
         Speed estimation pole (rad/s).
+    k_o1, k_o2 : Callable[[float], complex]
+        Observer gains as functions of the electrical angular speed of the rotor.
+    sensorless : bool
+        If True, sensorless mode is used.
     J : float, optional
         Inertia of the mechanical system (kgm²). Defaults to None, which means the
         mechanical system model is not used.
@@ -200,9 +201,10 @@ class SpeedFluxObserver:
     def __init__(
         self,
         par: InductionMachineInvGammaPars | InductionMachinePars,
+        alpha_o: float,
         k_o1: Callable[[float], complex],
         k_o2: Callable[[float], complex],
-        alpha_o: float,
+        sensorless: bool,
         J: float | None = None,
     ) -> None:
         # Configure observer gains for critically damped dynamics
@@ -212,10 +214,11 @@ class SpeedFluxObserver:
         else:
             k_w = 2 * alpha_o
             k_tau = J * alpha_o**2
-
         # Create component observers
         self.speed_observer = SpeedObserver(k_w, k_tau, J)
         self.flux_observer = FluxObserver(par, k_o1, k_o2)
+        # Choose sensored or sensorless mode
+        self.sensorless = sensorless
 
     def compute_output(
         self, u_s_ab: complex, i_s_ab: complex, w_M_meas: float | None
@@ -229,77 +232,59 @@ class SpeedFluxObserver:
             Stator voltage (V) in stator coordinates.
         i_s_ab : complex
             Stator current (A) in stator coordinates.
+        w_M_meas : float, optional
+            Measured mechanical rotor speed (rad/s), used only in sensored mode.
 
         Returns
         -------
         out : ObserverOutputs
-            Estimated feedback signals for the control system, including speed estimate.
+            Estimated feedback signals for the control system.
 
         """
         w_M, tau_L = self.speed_observer.compute_output()
         out = self.flux_observer.compute_output(u_s_ab, i_s_ab, w_M)
+        if not self.sensorless and w_M_meas is not None:
+            # Use the measured rotor speed in sensored mode
+            out.eps = w_M_meas - w_M
         out.tau_L = tau_L
         return out
 
     def update(self, T_s: float, out: ObserverOutputs) -> None:
         """Update state observers."""
-        self.flux_observer.update(T_s, out)
         self.speed_observer.update(T_s, out.eps, out.tau_M)
+        self.flux_observer.update(T_s, out)
 
 
 # %%
-def create_sensored_observer(
+def create_speed_flux_observer(
     par: InductionMachineInvGammaPars | InductionMachinePars,
+    alpha_o: float | None = None,
     k_o: Callable[[float], complex] | None = None,
-) -> FluxObserver:
-    """
-    Create a sensored observer.
-
-    The observer gains are ``k_o1 = k_o`` and ``k_o2 = 0``.
-
-    Parameters
-    ----------
-    par : InductionMachineInvGammaPars | InductionMachinePars
-        Machine model parameters.
-    k_o : Callable[[float], complex], optional
-        Observer gain as a function of the electrical angular speed of the rotor,
-        defaults to ``lambda w_m: 1 + 0.2*abs(w_m)/(R_R/L_M - 1j*w_m)``.
-
-    Returns
-    -------
-    FluxObserver
-        Sensored flux observer.
-
-    """
-
-    def default_k_o(w_m: float) -> complex:
-        return 1.0 + 0.2 * abs(w_m) / (par.alpha - 1j * w_m)
-
-    if k_o is None:
-        k_o = default_k_o
-    return FluxObserver(par, k_o, lambda w_m: 0)
-
-
-def create_sensorless_observer(
-    par: InductionMachineInvGammaPars | InductionMachinePars,
-    alpha_o: float = 2 * pi * 40,
-    k_o: Callable[[float], complex] | None = None,
+    sensorless: bool = True,
     J: float | None = None,
 ) -> SpeedFluxObserver:
     """
-    Create a sensorless flux observer with speed estimation.
+    Create a flux observer with speed estimation.
 
-    The observer gains are ``k_o1 = k_o`` and ``k_o2 = k_o``.
+    In sensored mode, the measured rotor speed is filtered. In sensorless mode, the
+    rotor speed is estimated based on the stator voltage and current. The observer gains
+    are ``k_o1 = k_o`` and ``k_o2 = k_o`` in sensorless mode, and ``k_o1 = k_o`` and
+    ``k_o2 = 0`` in sensored mode.
 
     Parameters
     ----------
     par : InductionMachineInvGammaPars | InductionMachinePars
         Machine model parameters.
-    alpha_o : float
-        Speed estimation pole (rad/s), defaults to 2*pi*40.
+    alpha_o : float, optional
+        Speed estimation pole (rad/s). If `None`, it defaults to 2*pi*40 in sensorless
+        mode and 2*pi*400 in sensored mode.
     k_o : Callable[[float], complex], optional
-        Observer gain as a function of the electrical angular speed of the rotor,
-        defaults to ``lambda w_m: (0.5*R_R/L_M + 0.2*abs(w_m))/(R_R/L_M - 1j*w_m)``.
+        Observer gain as a function of the electrical angular rotor speed. If `None`, it
+        defaults to ``lambda w_m: (0.5*par.alpha + 0.2*abs(w_m))/(par.alpha - 1j*w_m)``
+        in sensorless mode, and to ``lambda w_m: 1.0 + 0.2*abs(w_m)/(par.alpha
+        - 1j*w_m)`` in sensored mode.
+    sensorless : bool, optional
+        If True, sensorless control is used, defaults to True.
     J : float, optional
         Inertia of the mechanical system (kgm²). Defaults to None, which means the
         mechanical system model is not used.
@@ -307,17 +292,28 @@ def create_sensorless_observer(
     Returns
     -------
     SpeedFluxObserver
-        Sensorless flux observer with speed estimation.
+        Flux observer with speed estimation.
 
     """
+    if alpha_o is None:
+        alpha_o = 2 * pi * 40 if sensorless else 2 * pi * 400
 
-    def default_k_o(w_m: float) -> complex:
+    def default_k_o_sensorless(w_m: float) -> complex:
         return (0.5 * par.alpha + 0.2 * abs(w_m)) / (par.alpha - 1j * w_m)
 
-    if k_o is None:
-        k_o = default_k_o
+    def default_k_o_sensored(w_m: float) -> complex:
+        return 1.0 + 0.2 * abs(w_m) / (par.alpha - 1j * w_m)
 
-    return SpeedFluxObserver(par, k_o, k_o, alpha_o, J)
+    def zero_gain(_: float) -> complex:
+        return 0j
+
+    if sensorless:
+        k_o1 = k_o2 = default_k_o_sensorless if k_o is None else k_o
+    else:
+        k_o1 = default_k_o_sensored if k_o is None else k_o
+        k_o2 = zero_gain
+
+    return SpeedFluxObserver(par, alpha_o, k_o1, k_o2, sensorless, J)
 
 
 def create_vhz_observer(

--- a/motulator/drive/control/_sm_current_vector.py
+++ b/motulator/drive/control/_sm_current_vector.py
@@ -2,14 +2,13 @@
 
 from dataclasses import dataclass
 from math import inf, pi
-from typing import Callable
+from typing import Callable, cast
 
 from motulator.common.control import ComplexPIController
 from motulator.common.control._base import TimeSeries
 from motulator.drive.control._sm_observers import (
     ObserverOutputs,
-    create_sensored_observer,
-    create_sensorless_observer,
+    create_speed_flux_observer,
 )
 from motulator.drive.control._sm_reference_gen import ReferenceGenerator
 from motulator.drive.utils._parameters import (
@@ -99,16 +98,20 @@ class CurrentVectorControllerCfg:
     k_f : Callable[[float], float], optional
         PM-flux estimation gain as a function of the rotor angular speed.
     psi_s_min : float, optional
-        Minimum stator flux (Vs), defaults to `par.psi_f`.
+        Minimum stator flux (Vs), defaults to `par.psi_f` elsewhere.
     psi_s_max : float, optional
         Maximum stator flux (Vs), defaults to `inf`.
     k_u : float, optional
         Voltage utilization factor, defaults to 0.9.
     k_mtpv : float, optional
         MTPV margin, defaults to 0.9.
-    J : float, optional
+    J : float | None, optional
         Inertia (kgm²). Defaults to None, meaning the mechanical system model is not
         used in speed estimation.
+    sensorless : bool, optional
+        If True, sensorless control is used, defaults to True.
+    T_s : float, optional
+        Sampling period (s), defaults to 125e-6.
 
     """
 
@@ -123,6 +126,8 @@ class CurrentVectorControllerCfg:
     k_u: float = 0.9
     k_mtpv: float = 0.9
     J: float | None = None
+    sensorless: bool = True
+    T_s: float = 125e-6
 
     def __post_init__(self) -> None:
         """Set alpha_o default based on J value."""
@@ -143,10 +148,6 @@ class CurrentVectorController:
         Machine model parameters.
     cfg : CurrentVectorControllerCfg
         Current-vector control configuration.
-    sensorless : bool, optional
-        If True, sensorless control is used, defaults to True.
-    T_s : float, optional
-        Sampling period (s), defaults to 125e-6.
 
     """
 
@@ -154,24 +155,16 @@ class CurrentVectorController:
         self,
         par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
         cfg: CurrentVectorControllerCfg,
-        sensorless: bool = True,
-        T_s: float = 125e-6,
     ) -> None:
         self.reference_gen = ReferenceGenerator(
             par, cfg.i_s_max, cfg.psi_s_min, cfg.psi_s_max, cfg.k_u, cfg.k_mtpv
         )
         self.current_ctrl = CurrentController(par, cfg.alpha_c, cfg.alpha_i)
-        assert cfg.alpha_o is not None
-        if sensorless:
-            self.observer = create_sensorless_observer(
-                par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J
-            )
-        else:
-            self.observer = create_sensored_observer(
-                par, 2 * cfg.alpha_o, cfg.k_o, cfg.k_f
-            )
-        self.sensorless = sensorless
-        self.T_s = T_s
+        self.observer = create_speed_flux_observer(
+            par, cast(float, cfg.alpha_o), cfg.k_o, cfg.k_f, cfg.sensorless, cfg.J
+        )
+        self.sensorless = cfg.sensorless
+        self.T_s = cfg.T_s
 
     def get_feedback(
         self,
@@ -181,7 +174,7 @@ class CurrentVectorController:
         theta_M_meas: float | None,
     ) -> ObserverOutputs:
         """Get the feedback signals."""
-        return self.observer.compute_output(u_s_ab, i_s_ab, w_M_meas, theta_M_meas)
+        return self.observer.compute_output(u_s_ab, i_s_ab, theta_M_meas)
 
     def compute_output(self, tau_M_ref: float, fbk: ObserverOutputs) -> References:
         """Compute references."""

--- a/motulator/drive/control/_sm_flux_vector.py
+++ b/motulator/drive/control/_sm_flux_vector.py
@@ -2,13 +2,11 @@
 
 from dataclasses import dataclass
 from math import inf, pi
-from typing import Callable, Literal
+from typing import Callable, Literal, cast
 
 from motulator.common.control._base import TimeSeries
 from motulator.drive.control._sm_observers import (
     ObserverOutputs,
-    create_sensored_observer,
-    create_sensorless_observer,
     create_speed_flux_observer,
     create_vhz_observer,
 )
@@ -132,28 +130,32 @@ class FluxVectorControllerCfg:
         Maximum stator current (A).
     alpha_tau : float, optional
         Torque-control bandwidth (rad/s), defaults to 2*pi*100.
-    alpha_psi : float, optional
+    alpha_psi : float | None, optional
         Flux-control bandwidth (rad/s), defaults to `alpha_tau`.
-    alpha_i : float, optional
+    alpha_i : float | None, optional
         Integral-action bandwidth (rad/s), defaults to `alpha_tau`.
-    alpha_o : float, optional
+    alpha_o : float | None, optional
         Speed estimation poles (rad/s). Defaults to 2*pi*50 if `J` is None, otherwise
         2*pi*50/3, keeping the default speed observer gain the same.
-    k_o : Callable[[float], float], optional
+    k_o : Callable[[float], float] | None, optional
         Observer gain as a function of the rotor angular speed.
-    k_f : Callable[[float], float], optional
+    k_f : Callable[[float], float] | None, optional
         PM-flux estimation gain as a function of the rotor angular speed.
-    psi_s_min : float, optional
-        Minimum stator flux (Vs), defaults to `par.psi_f`.
+    psi_s_min : float | None, optional
+        Minimum stator flux (Vs). If None, defaults to `par.psi_f` elsewhere.
     psi_s_max : float, optional
         Maximum stator flux (Vs), defaults to `inf`.
     k_u : float, optional
         Voltage utilization factor, defaults to 0.9.
     k_mtpv : float, optional
         MTPV margin, defaults to 0.85.
-    J : float, optional
+    J : float | None, optional
         Inertia (kgm²). Defaults to None, meaning the mechanical system model is not
         used in speed estimation.
+    sensorless : bool, optional
+        If True, sensorless control is used, defaults to True.
+    T_s : float, optional
+        Sampling period (s), defaults to 125e-6.
 
     """
 
@@ -169,12 +171,15 @@ class FluxVectorControllerCfg:
     k_u: float = 0.9
     k_mtpv: float = 0.85
     J: float | None = None
+    sensorless: bool = True
+    T_s: float = 125e-6
 
     def __post_init__(self) -> None:
-        """Set alpha_o default based on J value."""
+        """Set alpha_o default based on J value and operation mode."""
         if self.alpha_o is None:
-            # To keep the speed observer gain k_w the same
-            alpha = 2 * pi * 50
+            # Note: If J is not given, alpha_o is divided by three to keep the default
+            # speed observer gain k_w the same.
+            alpha = 2 * pi * 50 if self.sensorless else 2 * pi * 400
             self.alpha_o = alpha if self.J is None else alpha / 3.0
 
 
@@ -195,10 +200,6 @@ class FluxVectorController:
         Machine model parameters.
     cfg : FluxVectorControllerCfg
         Flux-vector control configuration.
-    sensorless : bool, optional
-        If True, sensorless control is used, defaults to True.
-    T_s : float, optional
-        Sampling period (s), defaults to 125e-6.
 
     References
     ----------
@@ -221,8 +222,6 @@ class FluxVectorController:
         self,
         par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
         cfg: FluxVectorControllerCfg,
-        sensorless: bool = True,
-        T_s: float = 125e-6,
     ) -> None:
         self.reference_gen = ReferenceGenerator(
             par, cfg.i_s_max, cfg.psi_s_min, cfg.psi_s_max, cfg.k_u, cfg.k_mtpv
@@ -232,16 +231,17 @@ class FluxVectorController:
         self.flux_torque_ctrl = FluxTorqueController(
             par, alpha_psi, cfg.alpha_tau, alpha_i
         )
-        assert cfg.alpha_o is not None
-        self.observer = create_speed_flux_observer(par, cfg.alpha_o, cfg.k_o, cfg.k_f, cfg.J, sensorless)
-        self.sensorless = sensorless
-        self.T_s = T_s
+        self.observer = create_speed_flux_observer(
+            par, cast(float, cfg.alpha_o), cfg.k_o, cfg.k_f, cfg.sensorless, cfg.J
+        )  # alpha_o is resolved in the configuration's __post_init__
+        self.cfg = cfg
+        self.sensorless = cfg.sensorless
 
     def get_feedback(
         self,
         u_s_ab: complex,
         i_s_ab: complex,
-        w_M_meas: float | None,
+        w_M_meas: float | None,  # Not used, needed for the interface
         theta_M_meas: float | None,
     ) -> ObserverOutputs:
         """Get the feedback signals with motion sensors."""
@@ -249,7 +249,7 @@ class FluxVectorController:
 
     def compute_output(self, tau_M_ref: float, fbk: ObserverOutputs) -> References:
         """Compute references."""
-        ref = References(T_s=self.T_s, tau_M=tau_M_ref)
+        ref = References(T_s=self.cfg.T_s, tau_M=tau_M_ref)
         ref.psi_s, ref.tau_M = self.reference_gen.compute_flux_and_torque_refs(
             ref.tau_M, fbk.w_m, fbk.u_dc
         )
@@ -291,10 +291,12 @@ class ObserverBasedVHzControllerCfg:
         Voltage utilization factor, defaults to 0.9.
     k_mtpv : float, optional
         MTPV margin, defaults to 0.9.
-    psi_s_min : float, optional
-        Minimum stator flux (Vs), defaults to `par.psi_f`.
+    psi_s_min : float | None, optional
+        Minimum stator flux (Vs), defaults to `par.psi_f` elsewhere.
     psi_s_max : float, optional
         Maximum stator flux (Vs), defaults to `inf`.
+    T_s : float, optional
+        Sampling period (s), defaults to 250e-6.
 
     """
 
@@ -308,6 +310,7 @@ class ObserverBasedVHzControllerCfg:
     k_mtpv: float = 0.9
     psi_s_min: float | None = None
     psi_s_max: float = inf
+    T_s: float = 250e-6
 
 
 class ObserverBasedVHzController:
@@ -323,8 +326,6 @@ class ObserverBasedVHzController:
         Machine model parameters.
     cfg : ObserverBasedVHzControllerCfg
         Observer-based V/Hz control configuration.
-    T_s : float, optional
-        Sampling period (s), defaults to 250e-6.
 
     """
 
@@ -332,8 +333,8 @@ class ObserverBasedVHzController:
         self,
         par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
         cfg: ObserverBasedVHzControllerCfg,
-        T_s: float = 250e-6,
     ) -> None:
+        self.cfg = cfg
         self.pwm_mode: Literal["MPE", "MME", "six_step"] = "MME"
         self.reference_gen = ReferenceGenerator(
             par, cfg.i_s_max, cfg.psi_s_min, cfg.psi_s_max, cfg.k_u, cfg.k_mtpv
@@ -342,8 +343,7 @@ class ObserverBasedVHzController:
         self.observer = create_vhz_observer(par, cfg.alpha_o, cfg.k_o)
         self.alpha_f: float = cfg.alpha_f
         self.tau_M_lpf: float = 0.0  # Low-pass-filtered torque estimate
-        self.n_p = par.n_p
-        self.T_s = T_s
+        self.T_s = cfg.T_s
 
     def get_feedback(
         self, u_s_ab: complex, i_s_ab: complex, w_M_ref: float
@@ -354,7 +354,7 @@ class ObserverBasedVHzController:
 
     def compute_output(self, fbk: ObserverOutputs) -> References:
         """Calculate references."""
-        ref = References(T_s=self.T_s)
+        ref = References(T_s=self.cfg.T_s)
         ref.psi_s, ref.tau_M = self.reference_gen.compute_flux_and_torque_refs(
             self.tau_M_lpf, fbk.w_m, fbk.u_dc
         )

--- a/motulator/drive/control/_sm_observers.py
+++ b/motulator/drive/control/_sm_observers.py
@@ -94,7 +94,7 @@ class FluxObserver:
         self,
         u_s_ab: complex,
         i_s_ab: complex,
-        w_M: float | None,
+        w_M: float,
         theta_M_meas: float | None = None,
     ) -> ObserverOutputs:
         """
@@ -107,7 +107,7 @@ class FluxObserver:
         i_s_ab : complex
             Stator current (A) in stator coordinates.
         w_M : float
-            Mechanical rotor speed (rad/s), either measured or estimated.
+            Mechanical rotor speed (rad/s), typically from the speed observer.
         theta_M_meas : float, optional
             Measured mechanical rotor angle (rad), used only in sensored mode.
 
@@ -122,17 +122,11 @@ class FluxObserver:
         out = ObserverOutputs(psi_s=self.psi_s, psi_f=par.psi_f)
 
         # Get the rotor speed
-        if w_M is None:
-            raise ValueError("Either measured or estimated speed must be provided")
         out.w_M = w_M
         out.w_m = par.n_p * w_M
 
-        # Coordinate system angle equals the electrical rotor angle (or its estimate)
-        if self.sensorless or theta_M_meas is None:
-            out.theta_c = out.theta_m = self.theta_m
-        else:
-            out.theta_c = par.n_p * theta_M_meas
-            out.theta_m = self.theta_m
+        # Coordinate system angle equals the estimated rotor angle
+        out.theta_c = out.theta_m = self.theta_m
 
         # Current and voltage vectors in (estimated) rotor coordinates
         out.i_s = exp(-1j * out.theta_c) * i_s_ab
@@ -148,18 +142,17 @@ class FluxObserver:
         if self.sensorless:
             ratio = out.e_o / out.psi_a if out.psi_a != 0.0 else 0.0
             # Error signals for the mechanical rotor angle and PM flux estimation
-            err_elec = -ratio.imag
-            out.eps = err_elec / par.n_p
+            out.eps = -ratio.imag / par.n_p
             out.eps_f = -ratio.real
-
         else:
-            # Sensored mode assumes measured rotor angle, but speed is estimated
-            err_elec = wrap(par.n_p * theta_M_meas - out.theta_m)
-            out.eps = err_elec / par.n_p
+            # Sensored mode assumes measured rotor angle
+            if theta_M_meas is None:
+                raise ValueError("Rotor angle must be provided in sensored mode")
+            out.eps = wrap(par.n_p * theta_M_meas - out.theta_m) / par.n_p
             out.eps_f = 0
-        
+
         # Angular speed of the coordinate system
-        out.w_c = out.w_m + self.k_theta * err_elec
+        out.w_c = out.w_m + self.k_theta * par.n_p * out.eps
 
         # Torque estimate
         out.tau_M = 1.5 * par.n_p * (out.i_s * out.psi_s.conjugate()).imag
@@ -189,27 +182,28 @@ class SpeedFluxObserver:
     """
     Flux observer with speed estimation.
 
-    This observer estimates the stator flux linkage, the rotor angle, and rotor speed.
-    The observer gain decouples the electrical and mechanical dynamics and allows
-    placing the poles of the corresponding linearized estimation error dynamics. If the
-    inertia of the mechanical system is provided, the observer also estimates the load
-    torque, to avoid the lag in the speed estimate.
+    This observer estimates the stator flux linkage, rotor angle, and rotor speed. The
+    observer gain decouples the electrical and mechanical dynamics and allows placing
+    the poles of the corresponding linearized estimation error dynamics. If the inertia
+    of the mechanical system is provided, the observer also estimates the load torque,
+    to avoid the lag in the speed estimate. In sensored mode, the rotor speed is
+    estimated from the measured rotor angle.
 
     Parameters
     ----------
     par : SynchronousMachinePars | SaturatedSynchronousMachinePars
         Machine model parameters.
     alpha_o : float, optional
-        Speed-estimation pole location (rad/s).
+        Speed-estimation pole (rad/s).
     k_o : Callable[[float], float], optional
         Observer gain as a function of the rotor angular speed.
     k_f : Callable[[float], float], optional
         PM-flux estimation gain (V) as a function of the rotor angular speed.
+    sensorless : bool
+        If True, sensorless mode is used.
     J : float, optional
         Inertia of the mechanical system (kgm²). Defaults to None, which means the
         mechanical system model is not used.
-    sensorless : bool
-        If True, sensorless mode is used.
 
     """
 
@@ -219,8 +213,8 @@ class SpeedFluxObserver:
         alpha_o: float,
         k_o: Callable[[float], float],
         k_f: Callable[[float], float],
+        sensorless: bool,
         J: float | None = None,
-        sensorless: bool=True,        
     ) -> None:
         # Configure observer gains for critically damped dynamics
         if J is None:
@@ -231,19 +225,32 @@ class SpeedFluxObserver:
             k_theta = 3 * alpha_o
             k_w = 3 * alpha_o**2
             k_tau = J * alpha_o**3
-            
+
         # Create component observers
         self.speed_observer = SpeedObserver(k_w, k_tau, J)
         self.flux_observer = FluxObserver(par, k_theta, k_o, k_f, sensorless)
 
     def compute_output(
-        self,
-        u_s_ab: complex,
-        i_s_ab: complex,
-        # w_M_meas: float | None = None,
-        theta_M_meas: float | None = None,
+        self, u_s_ab: complex, i_s_ab: complex, theta_M_meas: float | None = None
     ) -> ObserverOutputs:
-        """Compute the feedback signals for the control system."""
+        """
+        Compute the feedback signals for the control system.
+
+        Parameters
+        ----------
+        u_s_ab : complex
+            Stator voltage (V) in stator coordinates.
+        i_s_ab : complex
+            Stator current (A) in stator coordinates.
+        theta_M_meas : float, optional
+            Measured mechanical rotor angle (rad), used only in sensored mode.
+
+        Returns
+        -------
+        out : ObserverOutputs
+            Estimated feedback signals for the control system.
+
+        """
         w_M, tau_L = self.speed_observer.compute_output()
         out = self.flux_observer.compute_output(u_s_ab, i_s_ab, w_M, theta_M_meas)
         out.tau_L = tau_L
@@ -255,105 +262,19 @@ class SpeedFluxObserver:
         self.flux_observer.update(T_s, out)
 
 
-# %%
-def create_sensored_observer(
-    par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
-    alpha_o: float = 2 * pi * 100,
-    k_o: Callable[[float], float] | None = None,
-    k_f: Callable[[float], float] | None = None,
-    J: float | None = None,
-) -> SpeedFluxObserver:
-    """
-    Create a sensored flux observer for a drive equipped with a rotor angle sensor.
-
-    Parameters
-    ----------
-    par : SynchronousMachinePars | SaturatedSynchronousMachinePars
-        Machine model parameters.
-    alpha_o : float, optional
-        Speed estimation pole (rad/s), defaults to 2*pi*100.
-    k_o : Callable[[float], float], optional
-        Observer gain as a function of the rotor angular speed, defaults to ``lambda
-        w_m: 0.25*(R_s*(L_d + L_q)/(L_d*L_q) + 0.2*abs(w_m))`` if `sensorless` else
-        ``lambda w_m: 2*pi*15``.
-    k_f : Callable[[float], float], optional
-        PM-flux estimation gain (V) as a function of the rotor angular speed, defaults
-        to zero, ``lambda w_m: 0``. A typical nonzero gain is of the form ``lambda w_m:
-        max(k*(abs(w_m) - w_min), 0)``, i.e., zero below the speed `w_min` (rad/s) and
-        linearly increasing above that with the slope `k` (Vs).
-    J : float, optional
-        Inertia of the mechanical system (kgm²). Defaults to None, which means the
-        mechanical system model is not used.
-
-    Returns
-    -------
-    SpeedFluxObserver
-        Sensorless flux observer with speed estimation.
-
-    """
-
-    k_o = (lambda w_m: 2 * pi * 15) if k_o is None else k_o
-    k_f = (lambda w_m: 0) if k_f is None else k_f
-
-    return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, False)
-
-
-def create_sensorless_observer(
-    par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
-    alpha_o: float = 2 * pi * 100,
-    k_o: Callable[[float], float] | None = None,
-    k_f: Callable[[float], float] | None = None,
-    J: float | None = None,
-) -> SpeedFluxObserver:
-    """
-    Create a sensorless flux observer with speed estimation.
-
-    Parameters
-    ----------
-    par : SynchronousMachinePars | SaturatedSynchronousMachinePars
-        Machine model parameters.
-    alpha_o : float, optional
-        Speed estimation pole (rad/s), defaults to 2*pi*100.
-    k_o : Callable[[float], float], optional
-        Observer gain as a function of the rotor angular speed, defaults to ``lambda
-        w_m: 0.25*(R_s*(L_d + L_q)/(L_d*L_q) + 0.2*abs(w_m))`` if `sensorless` else
-        ``lambda w_m: 2*pi*15``.
-    k_f : Callable[[float], float], optional
-        PM-flux estimation gain (V) as a function of the rotor angular speed, defaults
-        to zero, ``lambda w_m: 0``. A typical nonzero gain is of the form ``lambda w_m:
-        max(k*(abs(w_m) - w_min), 0)``, i.e., zero below the speed `w_min` (rad/s) and
-        linearly increasing above that with the slope `k` (Vs).
-    J : float, optional
-        Inertia of the mechanical system (kgm²). Defaults to None, which means the
-        mechanical system model is not used.
-
-    Returns
-    -------
-    SpeedFluxObserver
-        Sensorless flux observer with speed estimation.
-
-    """
-    # Poles at zero speed are located s = 0 and s = -2*sigma0
-    L_s0 = par.incr_ind_mat(0)
-    sigma0 = 0.25 * par.R_s * (1 / L_s0[0, 0] + 1 / L_s0[1, 1])
-
-    k_o = (lambda w_m: sigma0 + 0.2 * abs(w_m)) if k_o is None else k_o
-    k_f = (lambda w_m: 0) if k_f is None else k_f
-
-    return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, True)
-
 def create_speed_flux_observer(
     par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
     alpha_o: float = 2 * pi * 100,
     k_o: Callable[[float], float] | None = None,
     k_f: Callable[[float], float] | None = None,
-    J: float | None = None,
     sensorless: bool = True,
+    J: float | None = None,
 ) -> SpeedFluxObserver:
     """
-    Create a flux observer with a speed estimation. If rotor angle measurement is 
-    available, the observer estimates the speed is based on the angle measurement, 
-    otherwise it is estimated based on the flux estimation error.
+    Create a flux observer with speed estimation.
+
+    In sensored mode, the rotor speed is estimated based on the rotor angle measurement.
+    In sensorless mode, it is estimated based on the stator voltage and current.
 
     Parameters
     ----------
@@ -362,19 +283,19 @@ def create_speed_flux_observer(
     alpha_o : float, optional
         Speed estimation pole (rad/s), defaults to 2*pi*100.
     k_o : Callable[[float], float], optional
-        Observer gain as a function of the rotor angular speed, defaults to ``lambda
-        w_m: 0.25*(R_s*(L_d + L_q)/(L_d*L_q) + 0.2*abs(w_m))`` if `sensorless` else
-        ``lambda w_m: 2*pi*15``.
+        Observer gain as a function of the rotor speed, defaults to ``lambda w_m:
+        0.25*(R_s*(L_d + L_q)/(L_d*L_q) + 0.2*abs(w_m))`` if `sensorless` else ``lambda
+        w_m: 2*pi*15``.
     k_f : Callable[[float], float], optional
-        PM-flux estimation gain (V) as a function of the rotor angular speed, defaults
-        to zero, ``lambda w_m: 0``. A typical nonzero gain is of the form ``lambda w_m:
+        PM-flux estimation gain (V) as a function of the rotor speed, defaults to zero,
+        ``lambda w_m: 0``. A typical nonzero gain is of the form ``lambda w_m:
         max(k*(abs(w_m) - w_min), 0)``, i.e., zero below the speed `w_min` (rad/s) and
         linearly increasing above that with the slope `k` (Vs).
+    sensorless : bool, optional
+        If True, sensorless control is used, defaults to True.
     J : float, optional
         Inertia of the mechanical system (kgm²). Defaults to None, which means the
         mechanical system model is not used.
-    sensorless : bool, default True
-        If True, sensorless mode is used, otherwise sensored mode is used.
 
     Returns
     -------
@@ -393,7 +314,7 @@ def create_speed_flux_observer(
         k_o = (lambda w_m: 2 * pi * 15) if k_o is None else k_o
         k_f = (lambda w_m: 0) if k_f is None else k_f
 
-    return SpeedFluxObserver(par, alpha_o, k_o, k_f, J, sensorless)
+    return SpeedFluxObserver(par, alpha_o, k_o, k_f, sensorless, J)
 
 
 def create_vhz_observer(

--- a/motulator/drive/control/_sm_signal_inj.py
+++ b/motulator/drive/control/_sm_signal_inj.py
@@ -1,6 +1,7 @@
 """Sensorless control with signal injection for synchronous machine drives."""
 
 from cmath import exp
+from typing import cast
 
 from motulator.common.control._base import TimeSeries
 from motulator.common.utils._utils import wrap
@@ -91,11 +92,7 @@ class SignalInjectionObserver:
         return eps
 
     def compute_output(
-        self,
-        u_s_ab: complex,
-        i_s_ab: complex,
-        w_M: float | None,
-        theta_M_meas: float | None,
+        self, u_s_ab: complex, i_s_ab: complex, theta_M_meas: float | None
     ) -> ObserverOutputs:
         """Compute output."""
         # Unpack and initialize the output signals
@@ -148,8 +145,6 @@ class SignalInjectionController(CurrentVectorController):
         Current-vector control configuration.
     U_inj : float, optional
         Injected voltage amplitude (V), defaults to 250.
-    T_s : float, optional
-        Sampling period (s), defaults to 125e-6.
 
     References
     ----------
@@ -173,11 +168,11 @@ class SignalInjectionController(CurrentVectorController):
         par: SynchronousMachinePars | SaturatedSynchronousMachinePars,
         cfg: CurrentVectorControllerCfg,
         U_inj: float = 250,
-        T_s: float = 125e-6,
     ) -> None:
-        super().__init__(par, cfg, True, T_s)
-        assert cfg.alpha_o is not None
-        self.observer = SignalInjectionObserver(par, cfg.alpha_o, U_inj, T_s, cfg.J)
+        super().__init__(par, cfg)
+        self.observer = SignalInjectionObserver(
+            par, cast(float, cfg.alpha_o), U_inj, cfg.T_s, cfg.J
+        )
 
     def compute_output(self, tau_M_ref: float, fbk: ObserverOutputs) -> References:
         ref = References(T_s=self.T_s, tau_M=tau_M_ref)

--- a/motulator/grid/control/__init__.py
+++ b/motulator/grid/control/__init__.py
@@ -6,17 +6,27 @@ from motulator.grid.control._gfl_current_vector import (
     PLL,
     CurrentController,
     CurrentVectorController,
+    CurrentVectorControllerCfg,
 )
-from motulator.grid.control._gfm_observer import ObserverBasedGridFormingController
-from motulator.grid.control._gfm_psc import PowerSynchronizationController
+from motulator.grid.control._gfm_observer import (
+    ObserverBasedGridFormingController,
+    ObserverBasedGridFormingControllerCfg,
+)
+from motulator.grid.control._gfm_psc import (
+    PowerSynchronizationController,
+    PowerSynchronizationControllerCfg,
+)
 
 __all__ = [
     "CurrentController",
     "CurrentLimiter",
     "CurrentVectorController",
+    "CurrentVectorControllerCfg",
     "DCBusVoltageController",
     "GridConverterControlSystem",
     "ObserverBasedGridFormingController",
+    "ObserverBasedGridFormingControllerCfg",
     "PLL",
     "PowerSynchronizationController",
+    "PowerSynchronizationControllerCfg",
 ]

--- a/motulator/grid/control/_gfl_current_vector.py
+++ b/motulator/grid/control/_gfl_current_vector.py
@@ -135,9 +135,10 @@ class References:
     u_dc: float | None = None
 
 
-class CurrentVectorController:
+@dataclass
+class CurrentVectorControllerCfg:
     """
-    Current-vector grid-following controller.
+    Configuration for current-vector grid-following controller.
 
     Parameters
     ----------
@@ -147,11 +148,10 @@ class CurrentVectorController:
         Filter inductance (H).
     alpha_c : float, optional
         Current-control bandwidth (rad/s), defaults to 2*pi*400.
-    alpha_i : float, optional
+    alpha_i : float | None, optional
         Integral-action bandwidth (rad/s), defaults to `alpha_c`.
     u_nom : float, optional
-        Nominal grid voltage (V), line-to-neutral peak value, defaults to
-        `sqrt(2/3)*400`.
+        Nominal grid voltage (V), line-to-neutral peak value, defaults to sqrt(2/3)*400.
     w_nom : float, optional
         Nominal grid angular frequency (rad/s), defaults to 2*pi*50.
     alpha_pll : float, optional
@@ -161,21 +161,36 @@ class CurrentVectorController:
 
     """
 
-    def __init__(
-        self,
-        i_max: float,
-        L: float,
-        alpha_c: float = 2 * pi * 400,
-        alpha_i: float | None = None,
-        u_nom: float = sqrt(2 / 3) * 400,
-        w_nom: float = 2 * pi * 50,
-        alpha_pll: float = 2 * pi * 20,
-        T_s: float = 125e-6,
-    ) -> None:
-        self.current_ctrl = CurrentController(L, alpha_c, alpha_i)
-        self.pll = PLL(u_nom, w_nom, alpha_pll)
-        self.current_limiter = CurrentLimiter(i_max)
-        self.T_s = T_s
+    i_max: float
+    L: float
+    alpha_c: float = 2 * pi * 400
+    alpha_i: float | None = None
+    u_nom: float = sqrt(2 / 3) * 400
+    w_nom: float = 2 * pi * 50
+    alpha_pll: float = 2 * pi * 20
+    T_s: float = 125e-6
+
+    def __post_init__(self) -> None:
+        if self.alpha_i is None:
+            self.alpha_i = self.alpha_c
+
+
+class CurrentVectorController:
+    """
+    Current-vector grid-following controller.
+
+    Parameters
+    ----------
+    cfg : CurrentVectorControllerCfg
+        Configuration parameters.
+
+    """
+
+    def __init__(self, cfg: CurrentVectorControllerCfg) -> None:
+        self.cfg = cfg
+        self.current_ctrl = CurrentController(cfg.L, cfg.alpha_c, cfg.alpha_i)
+        self.pll = PLL(cfg.u_nom, cfg.w_nom, cfg.alpha_pll)
+        self.current_limiter = CurrentLimiter(cfg.i_max)
 
     def get_feedback(self, u_c_ab: complex, meas: Measurements) -> PLLOutputSignals:
         """Get feedback signals."""
@@ -186,7 +201,7 @@ class CurrentVectorController:
         self, p_g_ref: float, q_g_ref: float, fbk: PLLOutputSignals
     ) -> References:
         """Compute references."""
-        ref = References(T_s=self.T_s, p_g=p_g_ref, q_g=q_g_ref)
+        ref = References(T_s=self.cfg.T_s, p_g=p_g_ref, q_g=q_g_ref)
 
         # Compute the reference current
         ref.i_c = (ref.p_g - 1j * ref.q_g) / (1.5 * fbk.u_g)

--- a/motulator/grid/control/_gfm_observer.py
+++ b/motulator/grid/control/_gfm_observer.py
@@ -3,6 +3,7 @@
 from cmath import exp, phase
 from dataclasses import dataclass
 from math import pi, sqrt
+from typing import cast
 
 import numpy as np
 
@@ -106,21 +107,19 @@ class References:
     u_dc: float | None = None
 
 
-class ObserverBasedGridFormingController:
+@dataclass
+class ObserverBasedGridFormingControllerCfg:
     """
-    Disturbance-observer-based grid-forming controller.
-
-    This implements the RFPSC-type grid-forming mode of the control method described in
-    [#Nur2024]_. Transparent current control is also implemented.
+    Disturbance-observer-based grid-forming controller configuration.
 
     Parameters
     ----------
     i_max : float
         Maximum current (A), peak value.
     L : float
-        Total inductance (H).
+        Total inductance estimate (H).
     R : float, optional
-        Total series resistance (Ω), defaults to 0.
+        Total series resistance estimate (Ω), defaults to 0.
     R_a : float, optional
         Active resistance (Ω), defaults to `0.25*u_nom/i_max`.
     k_v : float, optional
@@ -132,8 +131,42 @@ class ObserverBasedGridFormingController:
     u_nom : float, optional
         Nominal grid voltage (V), line-to-neutral peak value, defaults to
         `sqrt(2/3)*400`.
+    w_nom : float, optional
+        Nominal grid angular frequency (rad/s), defaults to 2*pi*50.
     T_s : float, optional
         Sampling period (s), defaults to 125e-6.
+
+    """
+
+    i_max: float
+    L: float
+    R: float = 0.0
+    R_a: float | None = None
+    k_v: float | None = None
+    alpha_o: float = 2 * pi * 50
+    alpha_c: float = 2 * pi * 400
+    u_nom: float = sqrt(2 / 3) * 400
+    w_nom: float = 2 * pi * 50
+    T_s: float = 125e-6
+
+    def __post_init__(self) -> None:
+        if self.R_a is None:
+            self.R_a = 0.25 * self.u_nom / self.i_max
+        if self.k_v is None:
+            self.k_v = self.alpha_o / self.w_nom
+
+
+class ObserverBasedGridFormingController:
+    """
+    Disturbance-observer-based grid-forming controller.
+
+    This implements the RFPSC-type grid-forming mode of the control method described in
+    [#Nur2024]_. Transparent current control is also implemented.
+
+    Parameters
+    ----------
+    cfg : ObserverBasedGridFormingControllerCfg
+        Grid-forming control configuration.
 
     Notes
     -----
@@ -149,26 +182,15 @@ class ObserverBasedGridFormingController:
 
     """
 
-    def __init__(
-        self,
-        i_max: float,
-        L: float,
-        R: float = 0.0,
-        R_a: float | None = None,
-        k_v: float | None = None,
-        alpha_o: float = 2 * pi * 50,
-        alpha_c: float = 2 * pi * 400,
-        u_nom: float = sqrt(2 / 3) * 400,
-        w_nom: float = 2 * pi * 50,
-        T_s: float = 125e-6,
-    ) -> None:
-        self.observer = Observer(u_nom=u_nom, w_nom=w_nom, L=L, R=R, alpha_o=alpha_o)
-        self.current_limiter = CurrentLimiter(i_max)
-        # Initialize gains
-        self.R_a = 0.25 * u_nom / i_max if R_a is None else R_a
-        self.k_v = alpha_o / w_nom if k_v is None else k_v
-        self.k_c = alpha_c * L  # Current control gain
-        self.T_s: float = T_s
+    def __init__(self, cfg: ObserverBasedGridFormingControllerCfg) -> None:
+        self.observer = Observer(
+            u_nom=cfg.u_nom, w_nom=cfg.w_nom, L=cfg.L, R=cfg.R, alpha_o=cfg.alpha_o
+        )
+        self.current_limiter = CurrentLimiter(cfg.i_max)
+        self.R_a = cast(float, cfg.R_a)  # Resolved in the configuration's __post_init__
+        self.k_v = cast(float, cfg.k_v)
+        self.k_c = cfg.alpha_c * cfg.L  # Current control gain
+        self.T_s: float = cfg.T_s
 
     def get_feedback(self, u_c_ab: complex, meas: Measurements) -> ObserverOutputs:
         """Get the feedback signals."""

--- a/motulator/grid/control/_gfm_psc.py
+++ b/motulator/grid/control/_gfm_psc.py
@@ -3,6 +3,7 @@
 from cmath import exp
 from dataclasses import dataclass
 from math import pi
+from typing import cast
 
 from motulator.common.control._base import TimeSeries
 from motulator.common.utils._utils import wrap
@@ -35,11 +36,10 @@ class Feedbacks:
     w_c: float = 0.0  # Angular speed of the coordinate system (rad/s)
 
 
-class PowerSynchronizationController:
+@dataclass
+class PowerSynchronizationControllerCfg:
     """
-    Reference-feedforward power-synchronization controller.
-
-    This implements the reference-feedforward power-synchronization control [#Har2020]_.
+    Configuration for the reference-feedforward power-synchronization controller.
 
     Parameters
     ----------
@@ -51,12 +51,38 @@ class PowerSynchronizationController:
         Maximum current (A), peak value.
     R : float, optional
         Total series resistance (Ω), defaults to 0.
-    R_a : float, optional
-        Active resistance (Ω), defaults to 0.25*u_nom/i_max.
+    R_a : float | None, optional
+        Active resistance (Ω), defaults to ``0.25*u_nom/i_max``.
     w_b : float, optional
         Low-pass filter bandwidth (rad/s), defaults to 2*pi*5.
     T_s : float, optional
         Sampling period (s), defaults to 125e-6.
+
+    """
+
+    u_nom: float
+    w_nom: float
+    i_max: float
+    R: float = 0.0
+    R_a: float | None = None
+    w_b: float = 2 * pi * 5
+    T_s: float = 125e-6
+
+    def __post_init__(self) -> None:
+        if self.R_a is None:
+            self.R_a = 0.25 * self.u_nom / self.i_max
+
+
+class PowerSynchronizationController:
+    """
+    Reference-feedforward power-synchronization controller.
+
+    This implements the reference-feedforward power-synchronization control [#Har2020]_.
+
+    Parameters
+    ----------
+    cfg : PowerSynchronizationControllerCfg
+        Configuration object.
 
     References
     ----------
@@ -66,25 +92,13 @@ class PowerSynchronizationController:
 
     """
 
-    def __init__(
-        self,
-        u_nom: float,
-        w_nom: float,
-        i_max: float,
-        R: float = 0.0,
-        R_a: float | None = None,
-        w_b: float = 2 * pi * 5,
-        T_s: float = 125e-6,
-    ) -> None:
+    def __init__(self, cfg: PowerSynchronizationControllerCfg) -> None:
+        self.cfg = cfg
         self.theta_c: float = 0.0
         self.i_c_flt: complex = 0j
-        self.current_limiter = CurrentLimiter(i_max)
-        self.w_nom = w_nom
-        self.R = R
-        self.w_b = w_b
-        self.R_a = 0.25 * u_nom / i_max if R_a is None else R_a
-        self.k_p_psc = w_nom * self.R_a / (1.5 * u_nom**2)
-        self.T_s = T_s
+        self.current_limiter = CurrentLimiter(cfg.i_max)
+        self.R_a = cast(float, cfg.R_a)  # Resolved in the configuration's __post_init__
+        self.k_p_psc = cfg.w_nom * self.R_a / (1.5 * cfg.u_nom**2)
 
     def get_feedback(self, u_c_ab: complex, meas: Measurements) -> Feedbacks:
         """Get the feedback signals."""
@@ -95,7 +109,7 @@ class PowerSynchronizationController:
         out.u_c = exp(-1j * out.theta_c) * u_c_ab
 
         # Other feedback signals
-        p_loss = 1.5 * self.R * abs(out.i_c) ** 2
+        p_loss = 1.5 * self.cfg.R * abs(out.i_c) ** 2
         out.p_g = 1.5 * (out.u_c * out.i_c.conjugate()).real - p_loss
         return out
 
@@ -103,10 +117,10 @@ class PowerSynchronizationController:
         self, p_g_ref: float, v_c_ref: float, fbk: Feedbacks
     ) -> References:
         """Compute references."""
-        ref = References(T_s=self.T_s, v_c=v_c_ref, p_g=p_g_ref)
+        ref = References(T_s=self.cfg.T_s, v_c=v_c_ref, p_g=p_g_ref)
 
         # Power droop
-        fbk.w_c = ref.w_c = self.w_nom + self.k_p_psc * (ref.p_g - fbk.p_g)
+        fbk.w_c = ref.w_c = self.cfg.w_nom + self.k_p_psc * (ref.p_g - fbk.p_g)
 
         # Optionally, use of reference feedforward for d-axis current
         ref.i_c = ref.p_g / (1.5 * ref.v_c) + 1j * self.i_c_flt.imag
@@ -114,12 +128,12 @@ class PowerSynchronizationController:
         ref.i_c = self.current_limiter(ref.i_c)
 
         # Voltage reference
-        ref.u_c = ref.v_c + self.R_a * (ref.i_c - fbk.i_c) + self.R * fbk.i_c
+        ref.u_c = ref.v_c + self.R_a * (ref.i_c - fbk.i_c) + self.cfg.R * fbk.i_c
         return ref
 
     def update(self, ref: References, fbk: Feedbacks) -> None:
         """Update states."""
-        self.i_c_flt += ref.T_s * self.w_b * (fbk.i_c - self.i_c_flt)
+        self.i_c_flt += ref.T_s * self.cfg.w_b * (fbk.i_c - self.i_c_flt)
         self.theta_c += ref.T_s * ref.w_c
         self.theta_c = wrap(self.theta_c)
 

--- a/motulator/grid/utils/_identification.py
+++ b/motulator/grid/utils/_identification.py
@@ -68,9 +68,9 @@ class IdentificationCfg:
         If set to True, multiprocessing.Pool() is used to run the identification using
         all available CPU cores in the system. Defaults to True.
     filename : str | None, optional
-        If given, the identification result is saved in */data/{date}_{time}_{filename}
-        where * is the project root directory, defaults to None. The file format is set
-        by the `filetype` parameter.
+        If given, the identification result is saved in
+        ``data/{date}_{time}_{filename}`` (relative to the project root directory),
+        defaults to None. The file format is set by the `filetype` parameter.
     filetype : Literal["csv", "mat"], optional
         The filetype for saving identification results, defaults to "csv". Valid options
         are:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "motulator"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
     "numpy",
     "scipy",


### PR DESCRIPTION
Unify sensored and sensorless observers. Move `sensorless` and `T_s` parameters into the configuration dataclasses to simplify controller initialization. Update all drive and grid examples to be compatible with the new API.