### PR TITLE
Add main module importing checks to identification scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ If you would like to help us develop *motulator*, see these [guidelines](https:/
 Thanks go to these wonderful people:
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+
 <!-- prettier-ignore-start -->
+
 <!-- markdownlint-disable -->
+
 <table>
   <tbody>
     <tr>
@@ -83,6 +86,7 @@ Thanks go to these wonderful people:
 </table>
 
 <!-- markdownlint-restore -->
+
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/examples/grid/identification/plot_10kva_gfl_identification.py
+++ b/examples/grid/identification/plot_10kva_gfl_identification.py
@@ -54,6 +54,7 @@ ctrl.set_reactive_power_ref(0.5 * base.p)
 # %%
 # Run the identification and plot results.
 
-res = utils.run_identification(identification_cfg, mdl, ctrl)
-utils.plot_identification(res, plot_style="re_im")
-utils.plot_vector_identification(res, base)
+if __name__ == "__main__":
+    res = utils.run_identification(identification_cfg, mdl, ctrl)
+    utils.plot_identification(res, plot_style="re_im")
+    utils.plot_vector_identification(res, base)

--- a/examples/grid/identification/plot_13kva_do_gfm_identification.py
+++ b/examples/grid/identification/plot_13kva_do_gfm_identification.py
@@ -59,6 +59,7 @@ ctrl.set_ac_voltage_ref(base.u)
 # %%
 # Run the identification and plot results.
 
-res = utils.run_identification(identification_cfg, mdl, ctrl)
-utils.plot_identification(res, plot_style="re_im")
-utils.plot_vector_identification(res, base)
+if __name__ == "__main__":
+    res = utils.run_identification(identification_cfg, mdl, ctrl)
+    utils.plot_identification(res, plot_style="re_im")
+    utils.plot_vector_identification(res, base)


### PR DESCRIPTION
Add `if __name__ == "__main__` checks to identification scripts to avoid multiprocessing errors